### PR TITLE
Moe Sync

### DIFF
--- a/api/src/main/java/com/google/common/flogger/LogContext.java
+++ b/api/src/main/java/com/google/common/flogger/LogContext.java
@@ -132,7 +132,7 @@ public abstract class LogContext<
         MetadataKey.single("stack_size", StackSize.class);
   }
 
-  static final class MutableMetadata implements Metadata {
+  static final class MutableMetadata extends Metadata {
     /**
      * The default number of key/value pairs we initially allocate space for when someone adds
      * metadata to this context.
@@ -403,7 +403,7 @@ public abstract class LogContext<
    */
   @Override
   public final Metadata getMetadata() {
-    return metadata != null ? metadata : Metadata.EMPTY;
+    return metadata != null ? metadata : Metadata.empty();
   }
 
   @Override

--- a/api/src/main/java/com/google/common/flogger/backend/Metadata.java
+++ b/api/src/main/java/com/google/common/flogger/backend/Metadata.java
@@ -75,48 +75,58 @@ import javax.annotation.Nullable;
  * Finally, as the metadata keys should be unique, it is strongly encouraged that all keys are
  * defined as string literals.
  */
-public interface Metadata {
+public abstract class Metadata {
 
-  public static Metadata EMPTY =
-      new Metadata() {
-        @Override
-        public int size() {
-          return 0;
-        }
+  /** Returns an immutable {@link Metadata} that has no items. */
+  public static Metadata empty() {
+    return Empty.INSTANCE;
+  }
 
-        @Override
-        public MetadataKey<?> getKey(int n) {
-          throw new IndexOutOfBoundsException("cannot read from empty metadata");
-        }
+  // This is a static nested class as opposed to an anonymous class assigned to a constant field in
+  // order to decouple it's classload when Metadata is loaded. Android users are particularly
+  // careful about unnecessary class loading, and we've used similar mechanisms in Guava (see
+  // CharMatchers)
+  private static final class Empty extends Metadata {
+    static final Empty INSTANCE = new Empty();
 
-        @Override
-        public Object getValue(int n) {
-          throw new IndexOutOfBoundsException("cannot read from empty metadata");
-        }
+    @Override
+    public int size() {
+      return 0;
+    }
 
-        @Override
-        @Nullable
-        public <T> T findValue(MetadataKey<T> key) {
-          return null;
-        }
-      };
+    @Override
+    public MetadataKey<?> getKey(int n) {
+      throw new IndexOutOfBoundsException("cannot read from empty metadata");
+    }
+
+    @Override
+    public Object getValue(int n) {
+      throw new IndexOutOfBoundsException("cannot read from empty metadata");
+    }
+
+    @Override
+    @Nullable
+    public <T> T findValue(MetadataKey<T> key) {
+      return null;
+    }
+  }
 
   /** Returns the number of key/value pairs for this instance. */
-  int size();
+  public abstract int size();
 
   /**
    * Returns the key for the Nth piece of metadata.
    *
    * @throws IndexOutOfBoundsException if either {@code n < 0} or {n >= getCount()}.
    */
-  MetadataKey<?> getKey(int n);
+  public abstract MetadataKey<?> getKey(int n);
 
   /**
    * Returns the non-null value for the Nth piece of metadata.
    *
    * @throws IndexOutOfBoundsException if either {@code n < 0} or {n >= getCount()}.
    */
-  Object getValue(int n);
+  public abstract Object getValue(int n);
 
   /**
    * Returns the first value for the given metadata key, or null if it does not exist.
@@ -124,5 +134,5 @@ public interface Metadata {
    * @throws NullPointerException if {@code key} is {@code null}.
    */
   @Nullable
-  <T> T findValue(MetadataKey<T> key);
+  public abstract <T> T findValue(MetadataKey<T> key);
 }

--- a/api/src/test/java/com/google/common/flogger/testing/FakeMetadata.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FakeMetadata.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 
-public final class FakeMetadata implements Metadata {
+public final class FakeMetadata extends Metadata {
 
   private static final class KeyValuePair<T> {
     private final MetadataKey<T> key;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Convert Metadata.EMPTY to a static method

As a static final constant, this new class is automatically class loaded whenever Metadata is class loaded, instead of at first usage. Making a static method + inner class defers this class loading. This is obviously only a small win, but helps Android users who are very concerned about class loading at startup. Guava has attempted to do this with most of its static constants, such as CharMatcher

Because Flogger supports Java 6, this can't become a static method on Metadata without making it an abstract class.

b61a8d66c89a304cc5572d7c13955589a2aa7fcc