### PR TITLE
Moe Sync

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,5 +13,6 @@ package_group(
         "//android/...",
         "//api/...",
         "//google/...",
+        "//log4j/...",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,3 +21,9 @@ http_archive(
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")
 
 google_common_workspace_rules()
+
+maven_jar(
+    name = "log4j",
+    artifact = "log4j:log4j:1.2.17",
+    sha1 = "5af35056b4d257e4b64b9e8069c0746e8b08629f",
+)

--- a/log4j/BUILD
+++ b/log4j/BUILD
@@ -1,0 +1,55 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+# Author: ekempin@google.com (Edwin Kempin)
+#
+# Description:
+#   Flogger log4j backend (google.github.io/flogger).
+
+package(default_visibility = ["//:internal"])
+
+LOG4J_BACKEND_SRCS = glob(["src/main/java/com/google/common/flogger/backend/log4j/**/*.java"])
+
+java_library(
+    name = "log4j_backend",
+    srcs = LOG4J_BACKEND_SRCS,
+    javacopts = ["-source 1.6 -target 1.6"],
+    deps = [
+        "//api",
+        "//api:system_backend",
+        "@google_bazel_common//third_party/java/guava",
+        "@google_bazel_common//third_party/java/jsr305_annotations",
+        "@log4j//jar",
+    ],
+)
+
+load("//tools:maven.bzl", "pom_file")
+
+pom_file(
+    name = "log4j_backend_pom",
+    artifact_id = "flogger-log4j",
+    artifact_name = "Flogger Log4j Backend",
+    targets = [":log4j_backend"],
+)
+
+# ---- Unit Tests ----
+
+load("@google_bazel_common//testing:test_defs.bzl", "gen_java_tests")
+
+gen_java_tests(
+    name = "log4j_tests",
+    srcs = glob(
+        ["src/test/java/**/*.java"],
+    ),
+    deps = [
+        ":log4j_backend",
+        "//api",
+        "//api:testing",
+        "@google_bazel_common//third_party/java/auto:service",
+        "@google_bazel_common//third_party/java/guava",
+        "@google_bazel_common//third_party/java/guava:testlib",
+        "@google_bazel_common//third_party/java/jsr305_annotations",
+        "@google_bazel_common//third_party/java/junit",
+        "@google_bazel_common//third_party/java/mockito",
+        "@google_bazel_common//third_party/java/truth",
+        "@log4j//jar",
+    ],
+)

--- a/log4j/src/main/java/com/google/common/flogger/backend/log4j/Log4jBackendFactory.java
+++ b/log4j/src/main/java/com/google/common/flogger/backend/log4j/Log4jBackendFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 The Flogger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.flogger.backend.log4j;
+
+import com.google.common.flogger.backend.LoggerBackend;
+import com.google.common.flogger.backend.system.BackendFactory;
+import org.apache.log4j.Logger;
+
+/**
+ * BackendFactory for log4j.
+ *
+ * <p>To configure this backend for Flogger set the following system property (also see {@link
+ * com.google.common.flogger.backend.system.DefaultPlatform}):
+ *
+ * <ul>
+ *   <li>{@code flogger.backend_factory=
+ *       com.google.common.flogger.backend.log4j.Log4jBackendFactory#getInstance}.
+ * </ul>
+ */
+public final class Log4jBackendFactory extends BackendFactory {
+  private static final Log4jBackendFactory INSTANCE = new Log4jBackendFactory();
+
+  private Log4jBackendFactory() {}
+
+  /** This method is expected to be called via reflection (and might otherwise be unused). */
+  public static BackendFactory getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public LoggerBackend create(String loggingClassName) {
+    // Compute the logger name exactly the same way as in SimpleBackendFactory.
+    // The logger name must match the name of the logging class so that we can return it from
+    // Log4jLoggerBackend#getName().
+    // TODO(b/27920233): Strip inner/nested classes when deriving logger name.
+    Logger logger = Logger.getLogger(loggingClassName.replace('$', '.'));
+    return new Log4jLoggerBackend(logger);
+  }
+
+  @Override
+  public String toString() {
+    return "Log4j backend";
+  }
+}

--- a/log4j/src/main/java/com/google/common/flogger/backend/log4j/Log4jLoggerBackend.java
+++ b/log4j/src/main/java/com/google/common/flogger/backend/log4j/Log4jLoggerBackend.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 The Flogger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.flogger.backend.log4j;
+
+import com.google.common.flogger.backend.LogData;
+import com.google.common.flogger.backend.LoggerBackend;
+import org.apache.log4j.Logger;
+
+/** A logging backend that uses log4j to output log statements. */
+final class Log4jLoggerBackend extends LoggerBackend {
+  /** Converts java.util.logging.Level to org.apache.log4j.Level. */
+  static org.apache.log4j.Level toLog4jLevel(java.util.logging.Level level) {
+    if (level.intValue() >= java.util.logging.Level.SEVERE.intValue()) {
+      return org.apache.log4j.Level.ERROR;
+    } else if (level.intValue() >= java.util.logging.Level.WARNING.intValue()) {
+      return org.apache.log4j.Level.WARN;
+    } else if (level.intValue() >= java.util.logging.Level.INFO.intValue()) {
+      return org.apache.log4j.Level.INFO;
+    } else if (level.intValue() >= java.util.logging.Level.FINE.intValue()) {
+      return org.apache.log4j.Level.DEBUG;
+    }
+    return org.apache.log4j.Level.TRACE;
+  }
+
+  private final Logger logger;
+
+  // VisibleForTesting
+  Log4jLoggerBackend(Logger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public String getLoggerName() {
+    // Logger#getName() returns exactly the name that we used to create the Logger in
+    // Log4jBackendFactory. It matches the name of the logging class.
+    return logger.getName();
+  }
+
+  @Override
+  public boolean isLoggable(java.util.logging.Level level) {
+    return logger.isEnabledFor(toLog4jLevel(level));
+  }
+
+  private void log(SimpleLogEvent logEntry, boolean wasForced) {
+    if (wasForced || logger.isEnabledFor(logEntry.getLevel())) {
+      forceLog(logger, logEntry);
+    }
+  }
+
+  @Override
+  public void log(LogData logData) {
+    log(SimpleLogEvent.create(logger, logData), logData.wasForced());
+  }
+
+  @Override
+  public void handleError(RuntimeException error, LogData badData) {
+    log(SimpleLogEvent.error(logger, error, badData), badData.wasForced());
+  }
+
+  private void forceLog(Logger logger, SimpleLogEvent logEntry) {
+    // Logger#callAppenders circumvents any evaluation of whether to log or not to log.
+    logger.callAppenders(logEntry.asLoggingEvent());
+  }
+}

--- a/log4j/src/main/java/com/google/common/flogger/backend/log4j/LogDataFormatter.java
+++ b/log4j/src/main/java/com/google/common/flogger/backend/log4j/LogDataFormatter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2018 The Flogger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.flogger.backend.log4j;
+
+import static java.util.logging.Level.WARNING;
+
+import com.google.common.flogger.backend.LogData;
+import com.google.common.flogger.backend.Metadata;
+import com.google.common.flogger.backend.SimpleMessageFormatter;
+import com.google.common.flogger.backend.SimpleMessageFormatter.SimpleLogHandler;
+import java.util.logging.Level;
+
+/** Helper to format LogData */
+final class LogDataFormatter {
+  private LogDataFormatter() {}
+
+  /**
+   * Formats the log message and any metadata for the given {@link LogData}, calling the supplied
+   * receiver object with the results.
+   */
+  static void format(LogData logData, SimpleLogHandler receiver) {
+    SimpleMessageFormatter.format(logData, receiver);
+  }
+
+  /**
+   * Formats the log message in response to an exception during a previous logging attempt. A
+   * synthetic error message is generated from the original log data and the given exception is set
+   * as the cause. The level of this record is the maximum of WARNING or the original level.
+   */
+  static void formatBadLogData(
+      RuntimeException error, LogData badLogData, SimpleLogHandler receiver) {
+    StringBuilder errorMsg =
+        new StringBuilder("LOGGING ERROR: ").append(error.getMessage()).append('\n');
+    int length = errorMsg.length();
+    try {
+      appendLogData(badLogData, errorMsg);
+    } catch (RuntimeException e) {
+      // Reset partially written buffer when an error occurs.
+      errorMsg.setLength(length);
+      errorMsg.append("Cannot append LogData: ").append(e);
+    }
+
+    // Re-target this log message as a warning (or above) since it indicates a real bug.
+    Level level =
+        badLogData.getLevel().intValue() < WARNING.intValue() ? WARNING : badLogData.getLevel();
+
+    receiver.handleFormattedLogMessage(level, errorMsg.toString(), error);
+  }
+
+  /** Appends the given {@link LogData} to the given {@link StringBuilder}. */
+  static void appendLogData(LogData data, StringBuilder out) {
+    out.append("  original message: ");
+    if (data.getTemplateContext() == null) {
+      out.append(data.getLiteralArgument());
+    } else {
+      // We know that there's at least one argument to display here.
+      out.append(data.getTemplateContext().getMessage());
+      out.append("\n  original arguments:");
+      for (Object arg : data.getArguments()) {
+        out.append("\n    ").append(SimpleMessageFormatter.safeToString(arg));
+      }
+    }
+    Metadata metadata = data.getMetadata();
+    if (metadata.size() > 0) {
+      out.append("\n  metadata:");
+      for (int n = 0; n < metadata.size(); n++) {
+        out.append("\n    ");
+        out.append(metadata.getKey(n).getLabel()).append(": ").append(metadata.getValue(n));
+      }
+    }
+    out.append("\n  level: ").append(data.getLevel());
+    out.append("\n  timestamp (nanos): ").append(data.getTimestampNanos());
+    out.append("\n  class: ").append(data.getLogSite().getClassName());
+    out.append("\n  method: ").append(data.getLogSite().getMethodName());
+    out.append("\n  line number: ").append(data.getLogSite().getLineNumber());
+  }
+}

--- a/log4j/src/main/java/com/google/common/flogger/backend/log4j/SimpleLogEvent.java
+++ b/log4j/src/main/java/com/google/common/flogger/backend/log4j/SimpleLogEvent.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2018 The Flogger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.flogger.backend.log4j;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.flogger.LogSite;
+import com.google.common.flogger.backend.LogData;
+import com.google.common.flogger.backend.SimpleMessageFormatter.SimpleLogHandler;
+import java.util.concurrent.TimeUnit;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LocationInfo;
+import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.spi.ThrowableInformation;
+
+/** Class that represents a log entry that can be written to log4j. */
+final class SimpleLogEvent implements SimpleLogHandler {
+  /** Creates a {@link SimpleLogEvent} for a normal log statement from the given data. */
+  static SimpleLogEvent create(Logger logger, LogData data) {
+    return new SimpleLogEvent(logger, data);
+  }
+
+  /** Creates a {@link SimpleLogEvent} in the case of an error during logging. */
+  static SimpleLogEvent error(Logger logger, RuntimeException error, LogData data) {
+    return new SimpleLogEvent(logger, error, data);
+  }
+
+  private final Logger logger;
+  private final LogData logData;
+
+  private Level level;
+  private String message;
+  private Throwable thrown;
+
+  private SimpleLogEvent(Logger logger, LogData logData) {
+    this.logger = logger;
+    this.logData = logData;
+    LogDataFormatter.format(logData, this);
+  }
+
+  private SimpleLogEvent(Logger logger, RuntimeException error, LogData badLogData) {
+    this.logger = logger;
+    this.logData = badLogData;
+    LogDataFormatter.formatBadLogData(error, badLogData, this);
+  }
+
+  @Override
+  public void handleFormattedLogMessage(
+      java.util.logging.Level level, String message, Throwable thrown) {
+    this.level = Log4jLoggerBackend.toLog4jLevel(level);
+    this.message = message;
+    this.thrown = thrown;
+  }
+
+  Level getLevel() {
+    return level;
+  }
+
+  LoggingEvent asLoggingEvent() {
+    // The fully qualified class name of the logger instance is normally used to compute the log
+    // location (file, class, method, line number) from the stacktrace. Since we already have the
+    // log location in hand we don't need this computation. By passing in null as fully qualified
+    // class name of the logger instance we ensure that the log location computation is disabled.
+    // this is important since the log location computation is very expensive.
+    String fqnOfCategoryClass = null;
+
+    // The Nested Diagnostic Context (NDC) allows to include additional metadata into logs which
+    // are written from the current thread.
+    //
+    // Example:
+    //  NDC.push("user.id=" + userId);
+    //  // do business logic that triggers logs
+    //  NDC.pop();
+    //  NDC.remove();
+    //
+    // By using '%x' in the ConversionPattern of an appender this data can be included in the logs.
+    //
+    // We could include this data here by doing 'NDC.get()', but we don't want to encourage people
+    // using the log4j specific NDC. Instead this should be supported by a LoggingContext and usage
+    // of Flogger tags.
+    String nestedDiagnosticContext = "";
+
+    // The Mapped Diagnostic Context (MDC) allows to include additional metadata into logs which
+    // are written from the current thread.
+    //
+    // Example:
+    //  MDC.put("user.id", userId);
+    //  // do business logic that triggers logs
+    //  MDC.clear();
+    //
+    // By using '%X{key}' in the ConversionPattern of an appender this data can be included in the
+    // logs.
+    //
+    // We could include this data here by doing 'MDC.getContext()', but we don't want to encourage
+    // people using the log4j specific MDC. Instead this should be supported by a LoggingContext and
+    // usage of Flogger tags.
+    ImmutableMap<String, String> mdcProperties = ImmutableMap.of();
+
+    return new LoggingEvent(
+        fqnOfCategoryClass,
+        logger,
+        TimeUnit.NANOSECONDS.toMillis(logData.getTimestampNanos()),
+        level,
+        message,
+        Thread.currentThread().getName(),
+        thrown != null ? new ThrowableInformation(thrown) : null,
+        nestedDiagnosticContext,
+        getLocationInfo(),
+        mdcProperties);
+  }
+
+  private LocationInfo getLocationInfo() {
+    LogSite logSite = logData.getLogSite();
+    return new LocationInfo(
+        logSite.getFileName(),
+        logSite.getClassName(),
+        logSite.getMethodName(),
+        Integer.toString(logSite.getLineNumber()));
+  }
+
+  @Override
+  public String toString() {
+    // Note that this toString() method is _not_ safe against exceptions thrown by user toString().
+    StringBuilder out = new StringBuilder();
+    out.append(getClass().getSimpleName()).append(" {\n  message: ").append(message).append('\n');
+    LogDataFormatter.appendLogData(logData, out);
+    out.append("\n}");
+    return out.toString();
+  }
+}

--- a/log4j/src/test/java/com/google/common/flogger/backend/log4j/AssertingLogger.java
+++ b/log4j/src/test/java/com/google/common/flogger/backend/log4j/AssertingLogger.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2018 The Flogger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.flogger.backend.log4j;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.Priority;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * Helper class for testing the log4j backend.
+ *
+ * <p>This class implements a log4j Logger with assertion functionality. It captures the
+ * LoggingEvents so that they can be asserted later.
+ *
+ * <p>The message of the captured LoggingEvents is already formatted (it already contains all
+ * arguments and the metadata context was already appended).
+ *
+ * <p>Note that we do not just capture the LoggingEvent because we know that it's the action of
+ * calling some of the getters that causes work to be done (which is what any log handler would be
+ * expected to do).
+ *
+ * <p>Usage:
+ *
+ * <pre>
+ *   AssertingLogger logger = AssertingLogger.createOrGet("foo");
+ *   LoggerBackend backend = new Log4jLoggerBackend(logger);
+ *   backend.log(FakeLogData.of("Hello World"));
+ *   logger.assertLogCount(1);
+ *   logger.assertLogEntry(0, INFO, "Hello World");
+ * </pre>
+ */
+final class AssertingLogger extends Logger {
+
+  private static class LogEntry {
+    private final String message;
+    private final Level level;
+    private final Throwable thrown;
+
+    LogEntry(String message, Level level, Throwable thrown) {
+      this.message = message;
+      this.level = level;
+      this.thrown = thrown;
+    }
+  }
+
+  /**
+   * Returns an AssertionLogger with the given name.
+   *
+   * <p>If an AssertionLogger with this name was created before than the existing AssertionLogger
+   * instance is returned, otherwise a new AssertionLogger is created.
+   *
+   * <p>It is safe to call this method in parallel tests but it's up to the caller to use unique
+   * names if they want unique instances.
+   *
+   * @throws IllegalStateException if a logger with the given name already exists but is not an
+   *     AssertingLogger
+   */
+  static AssertingLogger createOrGet(String name) {
+    Logger logger = LogManager.getLogger(name, AssertingLogger::new);
+    checkState(
+        logger instanceof AssertingLogger,
+        "Logger %s already exists, but is not an AssertingLogger",
+        name);
+    return (AssertingLogger) logger;
+  }
+
+  private final List<AssertingLogger.LogEntry> entries = new ArrayList<>();
+
+  private AssertingLogger(String name) {
+    super(name);
+  }
+
+  @Override
+  public boolean isEnabledFor(Priority level) {
+    return true;
+  }
+
+  @Override
+  public void callAppenders(LoggingEvent event) {
+    entries.add(
+        new LogEntry(
+            event.getRenderedMessage(),
+            event.getLevel(),
+            event.getThrowableInformation() != null
+                ? event.getThrowableInformation().getThrowable()
+                : null));
+  }
+
+  String getMessage(int index) {
+    return entries.get(index).message;
+  }
+
+  void assertLogCount(int count) {
+    assertThat(entries.size()).isEqualTo(count);
+  }
+
+  void assertLogEntry(int index, Level level, String message) {
+    AssertingLogger.LogEntry entry = entries.get(index);
+    assertThat(entry.level).isEqualTo(level);
+    assertThat(entry.message).isEqualTo(message);
+    assertThat(entry.thrown).isNull();
+  }
+
+  void assertThrown(int index, Throwable thrown) {
+    assertThat(entries.get(index).thrown).isSameAs(thrown);
+  }
+}

--- a/log4j/src/test/java/com/google/common/flogger/backend/log4j/Log4jBackendLoggerTest.java
+++ b/log4j/src/test/java/com/google/common/flogger/backend/log4j/Log4jBackendLoggerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2018 The Flogger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.flogger.backend.log4j;
+
+import static com.google.common.flogger.LogFormat.PRINTF_STYLE;
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.log4j.Level.DEBUG;
+import static org.apache.log4j.Level.ERROR;
+import static org.apache.log4j.Level.INFO;
+import static org.apache.log4j.Level.TRACE;
+import static org.apache.log4j.Level.WARN;
+import static org.junit.Assert.fail;
+
+import com.google.common.flogger.LogContext;
+import com.google.common.flogger.MetadataKey;
+import com.google.common.flogger.backend.LogData;
+import com.google.common.flogger.backend.LoggerBackend;
+import com.google.common.flogger.parser.ParseException;
+import com.google.common.flogger.testing.FakeLogData;
+import org.apache.log4j.Hierarchy;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class Log4jBackendLoggerTest {
+  private static final MetadataKey<Integer> COUNT_KEY = MetadataKey.single("count", Integer.class);
+  private static final MetadataKey<String> ID_KEY = MetadataKey.single("id", String.class);
+
+  @Rule public TestName name = new TestName();
+
+  private static LoggerBackend newBackend(Logger logger) {
+    return new Log4jLoggerBackend(logger);
+  }
+
+  @Before
+  public void setup() {
+    removeCachedLoggers();
+  }
+
+  @After
+  public void cleanup() {
+    removeCachedLoggers();
+  }
+
+  @Test
+  public void testMessage() {
+    AssertingLogger logger = getAssertingLogger();
+    LoggerBackend backend = newBackend(logger);
+
+    backend.log(FakeLogData.of("Hello World"));
+    backend.log(FakeLogData.of(PRINTF_STYLE, "Hello %s %s", "Foo", "Bar"));
+
+    logger.assertLogCount(2);
+    logger.assertLogEntry(0, INFO, "Hello World");
+    logger.assertLogEntry(1, INFO, "Hello Foo Bar");
+  }
+
+  @Test
+  public void testMetadata() {
+    AssertingLogger logger = getAssertingLogger();
+    LoggerBackend backend = newBackend(logger);
+
+    backend.log(
+        FakeLogData.of(PRINTF_STYLE, "Foo='%s'", "bar")
+            .addMetadata(COUNT_KEY, 23)
+            .addMetadata(ID_KEY, "test ID"));
+
+    logger.assertLogCount(1);
+    logger.assertLogEntry(0, INFO, "Foo='bar' [CONTEXT count=23 id=\"test ID\" ]");
+  }
+
+  @Test
+  public void testLevels() {
+    AssertingLogger logger = getAssertingLogger();
+    LoggerBackend backend = newBackend(logger);
+
+    backend.log(FakeLogData.of("finest").setLevel(java.util.logging.Level.FINEST));
+    backend.log(FakeLogData.of("finer").setLevel(java.util.logging.Level.FINER));
+    backend.log(FakeLogData.of("fine").setLevel(java.util.logging.Level.FINE));
+    backend.log(FakeLogData.of("config").setLevel(java.util.logging.Level.CONFIG));
+    backend.log(FakeLogData.of("info").setLevel(java.util.logging.Level.INFO));
+    backend.log(FakeLogData.of("warning").setLevel(java.util.logging.Level.WARNING));
+    backend.log(FakeLogData.of("severe").setLevel(java.util.logging.Level.SEVERE));
+
+    logger.assertLogCount(7);
+    logger.assertLogEntry(0, TRACE, "finest");
+    logger.assertLogEntry(1, TRACE, "finer");
+    logger.assertLogEntry(2, DEBUG, "fine");
+    logger.assertLogEntry(3, DEBUG, "config");
+    logger.assertLogEntry(4, INFO, "info");
+    logger.assertLogEntry(5, WARN, "warning");
+    logger.assertLogEntry(6, ERROR, "severe");
+  }
+
+  @Test
+  public void testErrorHandling() {
+    AssertingLogger logger = getAssertingLogger();
+    LoggerBackend backend = newBackend(logger);
+
+    LogData data = FakeLogData.of(PRINTF_STYLE, "Hello %?X World", "ignored");
+    try {
+      backend.log(data);
+      fail("expected ParseException");
+    } catch (ParseException expected) {
+      logger.assertLogCount(0);
+      backend.handleError(expected, data);
+      logger.assertLogCount(1);
+      assertThat(logger.getMessage(0)).contains("lo %[?]X Wo");
+    }
+  }
+
+  @Test
+  public void testWithThrown() {
+    AssertingLogger logger = getAssertingLogger();
+    LoggerBackend backend = newBackend(logger);
+
+    Throwable cause = new Throwable("Original Cause");
+    backend.log(FakeLogData.of("Hello World").addMetadata(LogContext.Key.LOG_CAUSE, cause));
+
+    logger.assertLogCount(1);
+    logger.assertThrown(0, cause);
+  }
+
+  private AssertingLogger getAssertingLogger() {
+    // Each test requires a unique Logger instance. To ensure this the test method name is included
+    // into the logger name. This assumes that JUnit never runs the same test multiple times
+    // concurrently.
+    // Using "toUpperCase()" below is not strictly correct as regards locale etc, but since tests
+    // should not start with an upper case character, we should never get a clash.
+    String testMethod = name.getMethodName();
+    return AssertingLogger.createOrGet(
+        "LoggerFor" + testMethod.substring(0, 1).toUpperCase() + testMethod.substring(1));
+  }
+
+  private void removeCachedLoggers() {
+    ((Hierarchy) LogManager.getLoggerRepository()).clear();
+  }
+}

--- a/log4j/src/test/java/com/google/common/flogger/backend/log4j/LogDataFormatterTest.java
+++ b/log4j/src/test/java/com/google/common/flogger/backend/log4j/LogDataFormatterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2018 The Flogger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.flogger.backend.log4j;
+
+import static com.google.common.flogger.LogFormat.PRINTF_STYLE;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.flogger.LogContext;
+import com.google.common.flogger.MetadataKey;
+import com.google.common.flogger.backend.LogData;
+import com.google.common.flogger.backend.SimpleMessageFormatter.SimpleLogHandler;
+import com.google.common.flogger.testing.FakeLogData;
+import java.util.logging.Level;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class LogDataFormatterTest {
+  private static final MetadataKey<Integer> COUNT_KEY = MetadataKey.single("count", Integer.class);
+  private static final MetadataKey<String> ID_KEY = MetadataKey.single("id", String.class);
+
+  @Test
+  public void testFormatBadLogData() {
+    Throwable cause = new Throwable("Original Cause");
+    LogData data =
+        FakeLogData.of(PRINTF_STYLE, "Hello World").addMetadata(LogContext.Key.LOG_CAUSE, cause);
+
+    SimpleLogHandler handler = getSimpleLogHandler();
+    RuntimeException error = new RuntimeException("Runtime Error");
+    LogDataFormatter.formatBadLogData(error, data, handler);
+
+    String message = handler.toString();
+    assertThat(message).contains("message: Hello World");
+    assertThat(message).contains("level: INFO");
+    assertThat(message).contains("Original Cause");
+  }
+
+  @Test
+  public void testAppendLogData() {
+    LogData data =
+        FakeLogData.of(PRINTF_STYLE, "Foo='%s'", "bar")
+            .setTimestampNanos(123456789000L)
+            .addMetadata(COUNT_KEY, 23)
+            .addMetadata(ID_KEY, "test ID");
+
+    StringBuilder b = new StringBuilder();
+    LogDataFormatter.appendLogData(data, b);
+    assertThat(b.toString())
+        .isEqualTo(
+            "  original message: Foo='%s'\n"
+                + "  original arguments:\n"
+                + "    bar\n"
+                + "  metadata:\n"
+                + "    count: 23\n"
+                + "    id: test ID\n"
+                + "  level: INFO\n"
+                + "  timestamp (nanos): 123456789000\n"
+                + "  class: com.google.FakeClass\n"
+                + "  method: fakeMethod\n"
+                + "  line number: 123");
+  }
+
+  private static SimpleLogHandler getSimpleLogHandler() {
+    return new SimpleLogHandler() {
+      private String captured = null;
+
+      @Override
+      public void handleFormattedLogMessage(Level lvl, String msg, @Nullable Throwable e) {
+        captured = msg;
+      }
+
+      @Override
+      public String toString() {
+        return captured;
+      }
+    };
+  }
+}

--- a/log4j/src/test/java/com/google/common/flogger/backend/log4j/SimpleLogEventTest.java
+++ b/log4j/src/test/java/com/google/common/flogger/backend/log4j/SimpleLogEventTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018 The Flogger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.flogger.backend.log4j;
+
+import static com.google.common.flogger.LogFormat.PRINTF_STYLE;
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.log4j.Level.DEBUG;
+import static org.apache.log4j.Level.ERROR;
+import static org.apache.log4j.Level.INFO;
+import static org.apache.log4j.Level.TRACE;
+import static org.apache.log4j.Level.WARN;
+
+import com.google.common.flogger.LogContext;
+import com.google.common.flogger.MetadataKey;
+import com.google.common.flogger.backend.LogData;
+import com.google.common.flogger.testing.FakeLogData;
+import java.util.logging.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LocationInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SimpleLogEventTest {
+  private static final MetadataKey<Integer> COUNT_KEY = MetadataKey.single("count", Integer.class);
+  private static final MetadataKey<String> ID_KEY = MetadataKey.single("id", String.class);
+
+  private static SimpleLogEvent newSimpleLogEvent(LogData logData) {
+    return SimpleLogEvent.create(Logger.getLogger(logData.getLoggerName()), logData);
+  }
+
+  private static SimpleLogEvent newSimpleLogEvent(RuntimeException error, LogData logData) {
+    return SimpleLogEvent.error(Logger.getLogger(logData.getLoggerName()), error, logData);
+  }
+
+  @Test
+  public void testLoggerName() {
+    LogData data = FakeLogData.of("foo");
+    SimpleLogEvent logEvent = newSimpleLogEvent(data);
+    assertThat(logEvent.asLoggingEvent().getLoggerName()).isEqualTo(data.getLoggerName());
+  }
+
+  @Test
+  public void testLocationInfo() {
+    LogData data = FakeLogData.of("foo");
+    SimpleLogEvent logEvent = newSimpleLogEvent(data);
+
+    LocationInfo locationInfo = logEvent.asLoggingEvent().getLocationInformation();
+    assertThat(locationInfo.getClassName()).isEqualTo(data.getLogSite().getClassName());
+    assertThat(locationInfo.getMethodName()).isEqualTo(data.getLogSite().getMethodName());
+    assertThat(locationInfo.getFileName()).isEqualTo(data.getLogSite().getFileName());
+    assertThat(locationInfo.getLineNumber())
+        .isEqualTo(Integer.toString(data.getLogSite().getLineNumber()));
+  }
+
+  @Test
+  public void testLevels() {
+    testLevel(Level.FINEST, TRACE);
+    testLevel(Level.FINER, TRACE);
+    testLevel(Level.FINE, DEBUG);
+    testLevel(Level.CONFIG, DEBUG);
+    testLevel(Level.INFO, INFO);
+    testLevel(Level.WARNING, WARN);
+    testLevel(Level.SEVERE, ERROR);
+  }
+
+  private void testLevel(Level level, org.apache.log4j.Level expectedLevel) {
+    SimpleLogEvent logEvent = newSimpleLogEvent(FakeLogData.of(level.getName()).setLevel(level));
+    assertThat(logEvent.getLevel()).isEqualTo(expectedLevel);
+    assertThat(logEvent.asLoggingEvent().getLevel()).isEqualTo(expectedLevel);
+    assertThat(logEvent.asLoggingEvent().getMessage()).isEqualTo(level.getName());
+  }
+
+  @Test
+  public void testMessage() {
+    SimpleLogEvent logEvent = newSimpleLogEvent(FakeLogData.of("Hello World"));
+    assertThat(logEvent.asLoggingEvent().getMessage()).isEqualTo("Hello World");
+
+    logEvent = newSimpleLogEvent(FakeLogData.of(PRINTF_STYLE, "Hello %s %s", "Foo", "Bar"));
+    assertThat(logEvent.asLoggingEvent().getMessage()).isEqualTo("Hello Foo Bar");
+  }
+
+  @Test
+  public void testWithThrown() {
+    Throwable cause = new Throwable("Goodbye World");
+    LogData data =
+        FakeLogData.of(PRINTF_STYLE, "Hello World").addMetadata(LogContext.Key.LOG_CAUSE, cause);
+    SimpleLogEvent logEvent = newSimpleLogEvent(data);
+    assertThat(logEvent.asLoggingEvent().getThrowableInformation().getThrowable()).isSameAs(cause);
+  }
+
+  @Test
+  public void testErrorHandling() {
+    Throwable cause = new Throwable("Original Cause");
+    LogData data =
+        FakeLogData.of(PRINTF_STYLE, "Hello World").addMetadata(LogContext.Key.LOG_CAUSE, cause);
+
+    RuntimeException error = new RuntimeException("Runtime Error");
+    SimpleLogEvent logEvent = newSimpleLogEvent(error, data);
+
+    assertThat(logEvent.getLevel()).isEqualTo(WARN);
+    assertThat(logEvent.asLoggingEvent().getLevel()).isEqualTo(WARN);
+    assertThat(logEvent.asLoggingEvent().getThrowableInformation().getThrowable()).isEqualTo(error);
+
+    String message = (String) logEvent.asLoggingEvent().getMessage();
+    assertThat(message).contains("message: Hello World");
+    // This is formatted from the original log data.
+    assertThat(message).contains("level: INFO");
+    // The original cause is in the metadata of the original log data.
+    assertThat(message).contains("Original Cause");
+  }
+
+  @Test
+  public void testTimestamp() {
+    LogData data = FakeLogData.of(PRINTF_STYLE, "Foo='%s'", "bar").setTimestampNanos(123456000000L);
+    SimpleLogEvent logEvent = newSimpleLogEvent(data);
+    assertThat(logEvent.asLoggingEvent().getTimeStamp()).isEqualTo(123456L);
+  }
+
+  @Test
+  public void testMetadata() {
+    LogData data =
+        FakeLogData.of(PRINTF_STYLE, "Foo='%s'", "bar")
+            .addMetadata(COUNT_KEY, 23)
+            .addMetadata(ID_KEY, "test ID");
+
+    SimpleLogEvent logEvent = newSimpleLogEvent(data);
+    assertThat(logEvent.asLoggingEvent().getMessage())
+        .isEqualTo("Foo='bar' [CONTEXT count=23 id=\"test ID\" ]");
+  }
+
+  @Test
+  public void testToStringWithArgumentsAndMetadata() {
+    LogData data =
+        FakeLogData.of(PRINTF_STYLE, "Foo='%s'", "bar")
+            .setTimestampNanos(123456789000L)
+            .addMetadata(COUNT_KEY, 23)
+            .addMetadata(ID_KEY, "test ID");
+
+    SimpleLogEvent logEvent = newSimpleLogEvent(data);
+    assertThat(logEvent.toString())
+        .isEqualTo(
+            "SimpleLogEvent {\n"
+                + "  message: Foo='bar' [CONTEXT count=23 id=\"test ID\" ]\n"
+                + "  original message: Foo='%s'\n"
+                + "  original arguments:\n"
+                + "    bar\n"
+                + "  metadata:\n"
+                + "    count: 23\n"
+                + "    id: test ID\n"
+                + "  level: INFO\n"
+                + "  timestamp (nanos): 123456789000\n"
+                + "  class: com.google.FakeClass\n"
+                + "  method: fakeMethod\n"
+                + "  line number: 123\n"
+                + "}");
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a log4 backend for Flogger

We want to use Flogger in Gerrit where we currently use slf4j with a
log4j backend. We want to continue using log4j as backend so that the
switch to Flogger is transparent for existing Gerrit installations and
existing log4j configurations continue to work.

dc284ba2ef07346eb189b07da1d6cf4b504808fb