### PR TITLE
Replace @local_jdk usage with a java_toolchain

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -297,10 +297,11 @@ genrule(
     name = "gen_platform_provider",
     outs = ["platform_provider.jar"],
     cmd = "$(location :platform_provider_generator) com/google/common/flogger/backend/PlatformProvider.class" +
-          " && $(location @local_jdk//:bin/jar) cf $@ com/google/common/flogger/backend/PlatformProvider.class",
+          " && $(JAVABASE)/bin/jar cf $@ com/google/common/flogger/backend/PlatformProvider.class",
+    toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
     tools = [
         ":platform_provider_generator",
-        "@local_jdk//:bin/jar",
+        "@bazel_tools//tools/jdk:current_host_java_runtime",
     ],
 )
 


### PR DESCRIPTION
@local_jdk is deprecated and broken in some Bazel configurations.  This replaces its usage with the `@bazel_tools//tools/jdk:current_host_java_runtime` `java_toolchain`.