### PR TITLE
Exclude Guava dependency from log4j backend

### DIFF
--- a/log4j/BUILD
+++ b/log4j/BUILD
@@ -16,7 +16,6 @@ java_library(
     deps = [
         "//api",
         "//api:system_backend",
-        "@google_bazel_common//third_party/java/guava",
         "@google_bazel_common//third_party/java/jsr305_annotations",
         "@google_bazel_common//third_party/java/log4j",
     ],

--- a/log4j/src/main/java/com/google/common/flogger/backend/log4j/SimpleLogEvent.java
+++ b/log4j/src/main/java/com/google/common/flogger/backend/log4j/SimpleLogEvent.java
@@ -16,11 +16,12 @@
 
 package com.google.common.flogger.backend.log4j;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.LogSite;
 import com.google.common.flogger.backend.LogData;
 import com.google.common.flogger.backend.SimpleMessageFormatter.SimpleLogHandler;
 import java.util.concurrent.TimeUnit;
+import java.util.Collections;
+import java.util.Map;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LocationInfo;
@@ -108,7 +109,7 @@ final class SimpleLogEvent implements SimpleLogHandler {
     // We could include this data here by doing 'MDC.getContext()', but we don't want to encourage
     // people using the log4j specific MDC. Instead this should be supported by a LoggingContext and
     // usage of Flogger tags.
-    ImmutableMap<String, String> mdcProperties = ImmutableMap.of();
+    Map<String, String> mdcProperties = Collections.emptyMap();
 
     return new LoggingEvent(
         fqnOfCategoryClass,


### PR DESCRIPTION
Exclude Guava dependency from log4j backend because 
- Only `ImmutableMap` is used from Guava in `src/main`
 - As a transitive dependency it might cause conflict in projects which already depend on some version of Guava
 - As a transitive dependency it adds ~2.6M to the build which is quite a lot considering the number of Guava classes being used

Fixes #44