### PR TITLE
Moe Sync

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -302,10 +302,10 @@ java_binary(
 genrule(
     name = "gen_platform_provider",
     outs = ["platform_provider.jar"],
-    cmd = "$(location :platform_provider_generator) com/google/common/flogger/backend/PlatformProvider.class" +
-          " && $(JAVABASE)/bin/jar cf $@ com/google/common/flogger/backend/PlatformProvider.class",
-    toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
-    tools = [":platform_provider_generator"],
+    cmd = "$(location :platform_provider_generator) $@",
+    tools = [
+        ":platform_provider_generator",
+    ],
 )
 
 java_import(

--- a/api/src/main/java/com/google/common/flogger/backend/LogData.java
+++ b/api/src/main/java/com/google/common/flogger/backend/LogData.java
@@ -40,6 +40,7 @@ public interface LogData {
   long getTimestampMicros();
 
   /** Returns a nanosecond timestamp for the current log statement. */
+  @SuppressWarnings("GoodTime") // should return a java.time.Instant
   long getTimestampNanos();
 
   /**

--- a/api/src/main/java/com/google/common/flogger/backend/Platform.java
+++ b/api/src/main/java/com/google/common/flogger/backend/Platform.java
@@ -197,6 +197,7 @@ public abstract class Platform {
    * Warning: Not all Platform implementations will be able to deliver nanosecond precision and
    * code should avoid relying on any implied precision.
    */
+  @SuppressWarnings("GoodTime") // should return a java.time.Instant
   public static long getCurrentTimeNanos() {
     return LazyHolder.INSTANCE.getCurrentTimeNanosImpl();
   }

--- a/api/src/main/java/com/google/common/flogger/backend/system/Clock.java
+++ b/api/src/main/java/com/google/common/flogger/backend/system/Clock.java
@@ -27,5 +27,6 @@ public abstract class Clock {
    * though not necessarily nanosecond precision. This clock measures UTC and is not required to
    * handle leap seconds.
    */
+  @SuppressWarnings("GoodTime") // should return a java.time.Instant
   public abstract long getCurrentTimeNanos();
 }

--- a/api/src/test/java/com/google/common/flogger/testing/FakeLogData.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FakeLogData.java
@@ -80,6 +80,7 @@ public class FakeLogData implements LogData {
     this.arguments = arguments;
   }
 
+  @SuppressWarnings("GoodTime") // should accept a java.time.Instant
   public FakeLogData setTimestampNanos(long timestampNanos) {
     this.timestampNanos = timestampNanos;
     return this;

--- a/api/src/test/java/com/google/common/flogger/testing/TestLogger.java
+++ b/api/src/test/java/com/google/common/flogger/testing/TestLogger.java
@@ -53,6 +53,7 @@ public final class TestLogger extends AbstractLogger<TestLogger.Api> {
   }
 
   /** Logs at the given level, with the specified nanosecond timestamp. */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Instant
   public Api at(Level level, long timestampNanos) {
     return new TestContext(level, false, timestampNanos);
   }
@@ -63,6 +64,7 @@ public final class TestLogger extends AbstractLogger<TestLogger.Api> {
   }
 
   /** Forces logging at the given level, with the specified nanosecond timestamp. */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Instant
   public Api forceAt(Level level, long timestampNanos) {
     return new TestContext(level, true, timestampNanos);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Enable GoodTime API checker for Flogger

RELNOTES=suppress goodtime-api violations

9a681df3408464ebd003c9a0c7126042dc80648e

-------

<p> Make gen_platform_provider deterministic

because this uses the default jar tool, it encodes timestamps in the jar files

The easiest thing is just to have the tool directly produce the jar file instead of trying to use a jar tool

4080f60bd2573eac8f4c5282f3ac4d4dce2d6245