### PR TITLE
Add Github badges for Maven Central and Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Flogger: A Fluent Logging API for Java
+[![Maven Central](https://img.shields.io/maven-central/v/com.google.flogger/flogger.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.google.flogger%22%20AND%20a:%22flogger%22&core=gav) [![Javadocs](https://javadoc.io/badge/com.google.flogger/flogger.svg)](https://javadoc.io/doc/com.google.flogger/flogger)
+
 
 ## What is it?
 


### PR DESCRIPTION
Helpful for quickly:
- finding the current version
- exploring the Javadoc