### PR TITLE
Moe Sync

### DIFF
--- a/api/src/main/java/com/google/common/flogger/LogContext.java
+++ b/api/src/main/java/com/google/common/flogger/LogContext.java
@@ -665,14 +665,6 @@ public abstract class LogContext<
   }
 
   @Override
-  public final void logVarargs(String message, Object[] params) {
-    if (shouldLog()) {
-      // Copy the varargs array (because we didn't create it and this is quite a rare case).
-      logImpl(message, Arrays.copyOf(params, params.length));
-    }
-  }
-
-  @Override
   public final void log(String message, @Nullable Object p1) {
     if (shouldLog()) logImpl(message, p1);
   }
@@ -1234,5 +1226,13 @@ public abstract class LogContext<
   @Override
   public final void log(String message, double p1, double p2) {
     if (shouldLog()) logImpl(message, p1, p2);
+  }
+
+  @Override
+  public final void logVarargs(String message, Object[] params) {
+    if (shouldLog()) {
+      // Copy the varargs array (because we didn't create it and this is quite a rare case).
+      logImpl(message, Arrays.copyOf(params, params.length));
+    }
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Expose if logger.log(lazy()) is used so that these args can be filtered out.

lazy() returns a String, so currently a logger backend has no way of knowing if
the single argument was a compile time constant message, or a variable.

c1fa1254d1ea40a20609310307d4d3edaae53d0a