### PR TITLE
Moe Sync

### DIFF
--- a/api/src/test/java/com/google/common/flogger/testing/TestLogger.java
+++ b/api/src/test/java/com/google/common/flogger/testing/TestLogger.java
@@ -71,8 +71,8 @@ public final class TestLogger extends AbstractLogger<TestLogger.Api> {
 
   /** Logging context implementing the basic logging API. */
   private final class TestContext extends LogContext<TestLogger, Api> implements Api {
-    private TestContext(Level level, boolean isForced, long timestampMicros) {
-      super(level, isForced, timestampMicros);
+    private TestContext(Level level, boolean isForced, long timestampNanos) {
+      super(level, isForced, timestampNanos);
     }
 
     @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Renaming timestampMicros to timestampMillis/timestampNanos where appropriate.

There was no actual error in converting between timestamps, just the variable
names were incorrect.

Also fix flakyness in RotatingFileLoggerTest.

RELNOTES=N/A

7429c1a2d6ab4c69c1ec24f669e4f44708df91e5