### PR TITLE
Moe Sync

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,8 +16,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "google_bazel_common",
-    strip_prefix = "bazel-common-f1115e0f777f08c3cdb115526c4e663005bec69b",
-    urls = ["https://github.com/google/bazel-common/archive/f1115e0f777f08c3cdb115526c4e663005bec69b.zip"],
+    strip_prefix = "bazel-common-f3dc1a775d21f74fc6f4bbcf076b8af2f6261a69",
+    urls = ["https://github.com/google/bazel-common/archive/f3dc1a775d21f74fc6f4bbcf076b8af2f6261a69.zip"],
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")

--- a/api/src/main/java/com/google/common/flogger/LogContext.java
+++ b/api/src/main/java/com/google/common/flogger/LogContext.java
@@ -601,6 +601,20 @@ public abstract class LogContext<
   }
 
   @Override
+  public final <T> API with(MetadataKey<T> key, @Nullable T value) {
+    // Null keys are always bad (even if the value is also null). This is one of the few places
+    // where the logger API will throw a runtime exception (and as such it's important to ensure
+    // the NoOp implementation also does the check). The reasoning for this is that the metadata
+    // key is never expected to be passed user data, and should always be a static constant.
+    // Because of this it's always going to be an obvious code error if we get a null here.
+    checkNotNull(key, "metadata key");
+    if (value != null) {
+      addMetadata(key, value);
+    }
+    return api();
+  }
+
+  @Override
   public final API withCause(Throwable cause) {
     if (cause != null) {
       addMetadata(Key.LOG_CAUSE, cause);

--- a/api/src/test/java/com/google/common/flogger/FluentLoggerTest.java
+++ b/api/src/test/java/com/google/common/flogger/FluentLoggerTest.java
@@ -52,11 +52,11 @@ public class FluentLoggerTest {
     backend.setLevel(Level.INFO);
 
     // Down to and including the configured log level are not the no-op instance.
-    assertThat(logger.atSevere()).isNotSameAs(FluentLogger.NO_OP);
+    assertThat(logger.atSevere()).isNotSameInstanceAs(FluentLogger.NO_OP);
     assertThat(logger.atSevere()).isInstanceOf(Context.class);
-    assertThat(logger.atWarning()).isNotSameAs(FluentLogger.NO_OP);
+    assertThat(logger.atWarning()).isNotSameInstanceAs(FluentLogger.NO_OP);
     assertThat(logger.atWarning()).isInstanceOf(Context.class);
-    assertThat(logger.atInfo()).isNotSameAs(FluentLogger.NO_OP);
+    assertThat(logger.atInfo()).isNotSameInstanceAs(FluentLogger.NO_OP);
     assertThat(logger.atInfo()).isInstanceOf(Context.class);
 
     // Below the configured log level you only get the singleton no-op instance.
@@ -78,6 +78,6 @@ public class FluentLoggerTest {
     assertThat(logger.atSevere()).isSameAs(FluentLogger.NO_OP);
 
     backend.setLevel(Level.ALL);
-    assertThat(logger.atFinest()).isNotSameAs(FluentLogger.NO_OP);
+    assertThat(logger.atFinest()).isNotSameInstanceAs(FluentLogger.NO_OP);
   }
 }

--- a/api/src/test/java/com/google/common/flogger/LogContextTest.java
+++ b/api/src/test/java/com/google/common/flogger/LogContextTest.java
@@ -259,7 +259,7 @@ public class LogContextTest {
     backend.assertLastLogged().hasArguments("foo", "bar", "baz");
     // Make sure we took a copy of the arguments rather than risk re-using them.
     assertThat(backend.getLoggedCount()).isEqualTo(1);
-    assertThat(backend.getLogged(0).getArguments()).isNotSameAs(args);
+    assertThat(backend.getLogged(0).getArguments()).isNotSameInstanceAs(args);
   }
 
   @Test

--- a/api/src/test/java/com/google/common/flogger/LogSiteStackTraceTest.java
+++ b/api/src/test/java/com/google/common/flogger/LogSiteStackTraceTest.java
@@ -50,7 +50,7 @@ public class LogSiteStackTraceTest {
   public void testGetStackTrace() {
     StackTraceElement[] stack = FAKE_STACK.toArray(new StackTraceElement[0]);
     LogSiteStackTrace trace = new LogSiteStackTrace(null, StackSize.SMALL, stack);
-    assertThat(trace.getStackTrace()).isNotSameAs(stack);
+    assertThat(trace.getStackTrace()).isNotSameInstanceAs(stack);
     assertThat(trace.getStackTrace()).asList().isEqualTo(FAKE_STACK);
   }
 }

--- a/api/src/test/java/com/google/common/flogger/LogSiteStatsTest.java
+++ b/api/src/test/java/com/google/common/flogger/LogSiteStatsTest.java
@@ -41,7 +41,7 @@ public class LogSiteStatsTest {
 
     assertThat(stats1).isNotNull();
     assertThat(stats2).isNotNull();
-    assertThat(stats2).isNotSameAs(stats1);
+    assertThat(stats2).isNotSameInstanceAs(stats1);
     assertThat(map.getStatsForKey(logSite1)).isEqualTo(stats1);
     assertThat(map.getStatsForKey(logSite2)).isEqualTo(stats2);
   }

--- a/api/src/test/java/com/google/common/flogger/backend/FormatOptionsTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/FormatOptionsTest.java
@@ -48,7 +48,7 @@ public class FormatOptionsTest {
     assertThat(FormatOptions.parse("%x", 1, 1, false)).isSameAs(FormatOptions.getDefault());
     // Upper-case options are not the same as the default, but are the same if case is filtered out.
     FormatOptions upperDefault = FormatOptions.parse("%X", 1, 1, true);
-    assertThat(upperDefault).isNotSameAs(FormatOptions.getDefault());
+    assertThat(upperDefault).isNotSameInstanceAs(FormatOptions.getDefault());
   }
 
   @Test

--- a/api/src/test/java/com/google/common/flogger/parameter/SimpleParameterTest.java
+++ b/api/src/test/java/com/google/common/flogger/parameter/SimpleParameterTest.java
@@ -42,13 +42,13 @@ public class SimpleParameterTest {
     }
     // Different indices do not return the same instances.
     assertThat(SimpleParameter.of(1, FormatChar.DECIMAL, FormatOptions.getDefault()))
-        .isNotSameAs(SimpleParameter.of(0, FormatChar.DECIMAL, FormatOptions.getDefault()));
+        .isNotSameInstanceAs(SimpleParameter.of(0, FormatChar.DECIMAL, FormatOptions.getDefault()));
     // Different format chars do not return the same instances.
     assertThat(SimpleParameter.of(0, FormatChar.FLOAT, FormatOptions.getDefault()))
-        .isNotSameAs(SimpleParameter.of(0, FormatChar.DECIMAL, FormatOptions.getDefault()));
+        .isNotSameInstanceAs(SimpleParameter.of(0, FormatChar.DECIMAL, FormatOptions.getDefault()));
     // Different formatting options do not return the same instances.
     assertThat(SimpleParameter.of(0, FormatChar.DECIMAL, FormatOptions.parse("-10", 0, 3, false)))
-        .isNotSameAs(SimpleParameter.of(0, FormatChar.DECIMAL, FormatOptions.getDefault()));
+        .isNotSameInstanceAs(SimpleParameter.of(0, FormatChar.DECIMAL, FormatOptions.getDefault()));
   }
 
   @Test

--- a/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
@@ -16,6 +16,7 @@
 
 package com.google.common.flogger.testing;
 
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertAbout;
 
 import com.google.common.flogger.backend.FormatChar;
@@ -44,7 +45,7 @@ public final class FormatOptionsSubject extends Subject<FormatOptionsSubject, Fo
 
   public void isDefault() {
     if (!actual().isDefault()) {
-      fail("is default");
+      failWithActual(simpleFact("expected to be default"));
     }
   }
 
@@ -58,7 +59,7 @@ public final class FormatOptionsSubject extends Subject<FormatOptionsSubject, Fo
 
   public void hasNoFlags() {
     if (actual().getFlags() != 0) {
-      fail("has no flags");
+      failWithActual(simpleFact("expected to have no flags"));
     }
   }
 
@@ -148,13 +149,13 @@ public final class FormatOptionsSubject extends Subject<FormatOptionsSubject, Fo
 
   public void areValidFor(FormatChar formatChar) {
     if (!actual().areValidFor(formatChar)) {
-      fail("%s should be valid", formatChar);
+      failWithActual("expected to be valid for", formatChar);
     }
   }
 
   public void areNotValidFor(FormatChar formatChar) {
     if (actual().areValidFor(formatChar)) {
-      fail("%s should not be valid", formatChar);
+      failWithActual("expected not to be valid for", formatChar);
     }
   }
 }

--- a/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
@@ -49,15 +49,11 @@ public final class FormatOptionsSubject extends Subject<FormatOptionsSubject, Fo
   }
 
   public void hasPrecision(int precision) {
-    if (actual().getPrecision() != precision) {
-      fail("has precision", precision);
-    }
+    check("getPrecision()").that(actual().getPrecision()).isEqualTo(precision);
   }
 
   public void hasWidth(int width) {
-    if (actual().getWidth() != width) {
-      fail("has width", width);
-    }
+    check("getWidth()").that(actual().getWidth()).isEqualTo(width);
   }
 
   public void hasNoFlags() {

--- a/api/src/test/java/com/google/common/flogger/testing/FormatTypeSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatTypeSubject.java
@@ -55,13 +55,15 @@ public final class FormatTypeSubject extends Subject<FormatTypeSubject, FormatTy
   }
 
   public void isNumeric() {
-    assertWithMessage("Expected " + getSubject() + " to be numeric but wasn't")
+    check("isNumeric()")
+        .withMessage("Expected " + getSubject() + " to be numeric but wasn't")
         .that(getSubject().isNumeric())
         .isTrue();
   }
 
   public void isNotNumeric() {
-    assertWithMessage("Expected " + getSubject() + " to not be numeric but was")
+    check("isNumeric()")
+        .withMessage("Expected " + getSubject() + " to not be numeric but was")
         .that(getSubject().isNumeric())
         .isFalse();
   }

--- a/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
@@ -50,7 +50,7 @@ public final class LogDataSubject extends Subject<LogDataSubject, LogData> {
 
   /** Asserts about the metadata of this log entry. */
   public MetadataSubject metadata() {
-    return check().about(MetadataSubject.metadata()).that(actual().getMetadata());
+    return check("getMetadata()").about(MetadataSubject.metadata()).that(actual().getMetadata());
   }
 
   /**

--- a/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
@@ -18,7 +18,6 @@ package com.google.common.flogger.testing;
 
 import static com.google.common.truth.Truth.assertAbout;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.backend.LogData;
 import com.google.common.truth.FailureMetadata;
@@ -61,14 +60,12 @@ public final class LogDataSubject extends Subject<LogDataSubject, LogData> {
   public void hasMessage(Object messageOrLiteral) {
     if (actual().getTemplateContext() == null) {
       // Expect literal argument (possibly null).
-      if (!Objects.equal(actual().getLiteralArgument(), messageOrLiteral)) {
-        fail("has literal", messageOrLiteral);
-      }
+      check("getLiteralArgument()").that(actual().getLiteralArgument()).isEqualTo(messageOrLiteral);
     } else {
       // Expect message string (non null).
-      if (!actual().getTemplateContext().getMessage().equals(messageOrLiteral)) {
-        fail("has format message", messageOrLiteral);
-      }
+      check("getTemplateContext().getMessage()")
+          .that(actual().getTemplateContext().getMessage())
+          .isEqualTo(messageOrLiteral);
     }
   }
 

--- a/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
@@ -86,7 +86,7 @@ public final class MetadataSubject extends Subject<MetadataSubject, Metadata> {
       // The key must exist, so neither method will return -1.
       List<MetadataKey<?>> keys = keyList();
       if (keys.indexOf(key) != keys.lastIndexOf(key)) {
-        fail("has unique key", key);
+        failWithActual("expected to have unique key", key);
       }
     }
   }

--- a/google/src/main/java/com/google/common/flogger/GoogleLogContext.java
+++ b/google/src/main/java/com/google/common/flogger/GoogleLogContext.java
@@ -18,10 +18,8 @@ package com.google.common.flogger;
 
 import com.google.common.flogger.parser.DefaultPrintfMessageParser;
 import com.google.common.flogger.parser.MessageParser;
-import com.google.common.flogger.util.Checks;
 import com.google.errorprone.annotations.CheckReturnValue;
 import java.util.logging.Level;
-import javax.annotation.Nullable;
 
 /**
  * Implementation of any Google specific extensions to the default fluent logging API. This could
@@ -52,19 +50,5 @@ public abstract class GoogleLogContext<
   @Override
   protected final MessageParser getMessageParser() {
     return DefaultPrintfMessageParser.getInstance();
-  }
-
-  @Override
-  public final <T> API with(MetadataKey<T> key, @Nullable T value) {
-    // Null keys are always bad (even if the value is also null). This is one of the few places
-    // where the logger API will throw a runtime exception (and as such it's important to ensure
-    // the NoOp implementation also does the check). The reasoning for this is that the metadata
-    // key is never expected to be passed user data, and should always be a static constant.
-    // Because of this it's always going to be an obvious code error if we get a null here.
-    Checks.checkNotNull(key, "metadata key");
-    if (value != null) {
-      addMetadata(key, value);
-    }
-    return api();
   }
 }

--- a/google/src/main/java/com/google/common/flogger/GoogleLoggingApi.java
+++ b/google/src/main/java/com/google/common/flogger/GoogleLoggingApi.java
@@ -16,9 +16,7 @@
 
 package com.google.common.flogger;
 
-import com.google.common.flogger.util.Checks;
 import com.google.errorprone.annotations.CheckReturnValue;
-import javax.annotation.Nullable;
 
 /**
  * Google specific extensions to the fluent logging API.
@@ -39,42 +37,5 @@ public interface GoogleLoggingApi<API extends GoogleLoggingApi<API>> extends Log
    * An implementation of {@link GoogleLoggingApi} which does nothing and discards all parameters.
    */
   public static class NoOp<API extends GoogleLoggingApi<API>> extends LoggingApi.NoOp<API>
-      implements GoogleLoggingApi<API> {
-
-    @Override
-    public final <T> API with(MetadataKey<T> key, @Nullable T value) {
-      // Identical to the check in GoogleLogContext for consistency.
-      Checks.checkNotNull(key, "metadata key");
-      return noOp();
-    }
-  }
-
-  /**
-   * Associates a metadata key constant with a runtime value for this log statement in a structured
-   * way that is accessible to logger backends.
-   *
-   * <p>This method is not a replacement for general parameter passing in the {@link #log()} method
-   * and should be reserved for keys/values with specific semantics. Examples include:
-   * <ul>
-   *   <li>Keys that are recognised by specific logger backends (typically to control logging
-   *       behaviour in some way).
-   *   <li>Key value pairs which are explicitly extracted from logs by tools.
-   * </ul>
-   *
-   * <p>Metadata keys can support repeated values (see {@link MetadataKey#canRepeat()}), and if a
-   * repeatable key is used multiple times in the same log statement, the effect is to collect all
-   * the given values in order. If a non-repeatable key is passed multiple times, only the last
-   * value is retained (though callers should not rely on this behavior and should simply avoid
-   * repeating non-repeatable keys).
-   *
-   * <p>If {@code value} is {@code null}, this method is a no-op. This is useful for specifying
-   * conditional values (e.g. via {@code logger.atInfo().with(MY_KEY, getValueOrNull()).log(...)}).
-   *
-   * @param key the metadata key (expected to be a static constant)
-   * @param value a value to be associated with the key in this log statement. Null values are
-   *        allowed, but the effect is always a no-op
-   * @throws NullPointerException if the given key is null
-   * @see MetadataKey
-   */
-  <T> API with(MetadataKey<T> key, @Nullable T value);
+      implements GoogleLoggingApi<API> { }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate Truth Subjects from no-arg check() to the overload that accepts a description.

The overload that accepts a description generally produces better failure messages:
- The first line of the message it produces is something like: "value of: myProto.getResponse()" (where "getResponse()" is taken from the provided description)
- The last line of the message it produces is something like: "myProto was: response: query was throttled" (the full value of myProto)
- And the existing text goes in between.

Additional motivation: We have deprecated the no-arg overload in open-source Truth.

Note that the new overload is available externally as of Truth 0.40.

dfc80b187e8cb8645a06351eb145d01bbcc8bdcc

-------

<p> Migrate Truth subjects from a manual "test and fail" approach to one using Subject.check(...).

Before:
  if (actual().foo() != expected) {
    fail("has foo", expected);
  }

After:
  check("foo()").that(actual().foo()).isEqualTo(expected);

This CL changes the format of the failure message. The new message will typically contain the same information as the old, but if some is missing, let us know, and consider adding a test.

Open-source note: The overload of check(...) used by this CL was added in Truth 0.40.

8fd700499cc26ed67efb154cf422a47a5ff0ec69

-------

<p> For assertions made _inside the implementation of another assertion_, migrate from assertThat to check.

For example:
  assertThat(actual().foo()).isEqualTo(expected);
becomes:
  check("foo()").that(actual().foo()).isEqualTo(expected);

445618fc9b4392a08b7e1a5aa6e434b0ec33ec2f

-------

<p> Update to new bazel_common to pick up Truth 0.44 -- and Guava 27.1.

cd9c03046d64048ad6c689bd8a01b183a0ec7995

-------

<p> Promoting with() method to public FluentLogger since it's starting to be useful outside of GoogleLogger (there's a thread in open source where I just recommended it to someone forgetting that it's not public).

This went through API review before, and there have been no issues with it internally, but it's not used super heavily (which is good, since it's "advanced mode") so it's not been through a proper "trial by fire" inside [] really.

If anyone can think of any reason for _not_ doing this, please speak up!

Relnotes:
  - Promoting the "`with()`" method from `GoogleLogger` to `FluentLogger`.
    - This is useful to piggyback semantic information _about_ the log statement into For example, identifying special log statements which should be handled differently (e.g. sent to a different log file).

6e6d8f86eee0fcf541387d81faae1b45a002e51a

-------

<p> Migrate Truth subjects from the old fail(String, Object) to the new failWithActual(String, Object), tweaking verbs for the new grammar.

Before:
  fail("has foo", expected);

After:
  failWithActual("expected to have foo", expected);

41728e919d3ca25d61d6816303a76d2b702a51c7

-------

<p> Migrate from isNotSameAs to isNotSameInstanceAs.

The two behave identically, and isNotSameAs is being removed.

d2c6029d954089a48c9fac2f614d53c84052c143