### PR TITLE
Moe Sync

### DIFF
--- a/api/src/test/java/com/google/common/flogger/FluentLoggerTest.java
+++ b/api/src/test/java/com/google/common/flogger/FluentLoggerTest.java
@@ -60,9 +60,9 @@ public class FluentLoggerTest {
     assertThat(logger.atInfo()).isInstanceOf(Context.class);
 
     // Below the configured log level you only get the singleton no-op instance.
-    assertThat(logger.atFine()).isSameAs(FluentLogger.NO_OP);
-    assertThat(logger.atFiner()).isSameAs(FluentLogger.NO_OP);
-    assertThat(logger.atFinest()).isSameAs(FluentLogger.NO_OP);
+    assertThat(logger.atFine()).isSameInstanceAs(FluentLogger.NO_OP);
+    assertThat(logger.atFiner()).isSameInstanceAs(FluentLogger.NO_OP);
+    assertThat(logger.atFinest()).isSameInstanceAs(FluentLogger.NO_OP);
 
     // Just verify that logs below the current log level are discarded.
     logger.atFine().log("DISCARDED");
@@ -75,7 +75,7 @@ public class FluentLoggerTest {
     assertThat(backend.getLoggedCount()).isEqualTo(1);
 
     backend.setLevel(Level.OFF);
-    assertThat(logger.atSevere()).isSameAs(FluentLogger.NO_OP);
+    assertThat(logger.atSevere()).isSameInstanceAs(FluentLogger.NO_OP);
 
     backend.setLevel(Level.ALL);
     assertThat(logger.atFinest()).isNotSameInstanceAs(FluentLogger.NO_OP);

--- a/api/src/test/java/com/google/common/flogger/LogContextTest.java
+++ b/api/src/test/java/com/google/common/flogger/LogContextTest.java
@@ -573,7 +573,7 @@ public class LogContextTest {
     // This doesn't check anything about the message that's printed before the stack lines,
     // but that's not the point of this test.
     assertThat(expectedLines).hasSize(syntheticStackSize);
-    assertThat(actualStackLines).containsAllIn(expectedLines).inOrder();
+    assertThat(actualStackLines).containsAtLeastElementsIn(expectedLines).inOrder();
   }
 
   private static StackTraceElement getCallerInfoFollowingLine() {

--- a/api/src/test/java/com/google/common/flogger/LogSiteStackTraceTest.java
+++ b/api/src/test/java/com/google/common/flogger/LogSiteStackTraceTest.java
@@ -43,7 +43,7 @@ public class LogSiteStackTraceTest {
     Throwable cause = new RuntimeException();
     LogSiteStackTrace trace =
         new LogSiteStackTrace(cause, StackSize.SMALL, new StackTraceElement[0]);
-    assertThat(trace.getCause()).isSameAs(cause);
+    assertThat(trace.getCause()).isSameInstanceAs(cause);
   }
 
   @Test

--- a/api/src/test/java/com/google/common/flogger/backend/FormatCharTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/FormatCharTest.java
@@ -37,7 +37,7 @@ public class FormatCharTest {
 
   private static void assertFormatType(FormatType type, FormatChar... formatChars) {
     for (FormatChar fc : formatChars) {
-      assertThat(fc.getType()).isSameAs(type);
+      assertThat(fc.getType()).isSameInstanceAs(type);
     }
   }
 

--- a/api/src/test/java/com/google/common/flogger/backend/FormatOptionsTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/FormatOptionsTest.java
@@ -45,7 +45,7 @@ public class FormatOptionsTest {
 
   @Test
   public void testParsingDefault() throws ParseException {
-    assertThat(FormatOptions.parse("%x", 1, 1, false)).isSameAs(FormatOptions.getDefault());
+    assertThat(FormatOptions.parse("%x", 1, 1, false)).isSameInstanceAs(FormatOptions.getDefault());
     // Upper-case options are not the same as the default, but are the same if case is filtered out.
     FormatOptions upperDefault = FormatOptions.parse("%X", 1, 1, true);
     assertThat(upperDefault).isNotSameInstanceAs(FormatOptions.getDefault());
@@ -200,7 +200,7 @@ public class FormatOptionsTest {
 
     FormatOptions options = parse("+- #0,123.456", true);
     assertThat(options.filter(0, false, false)).isDefault();
-    assertThat(options.filter(ALL_FLAGS, true, true)).isSameAs(options);
+    assertThat(options.filter(ALL_FLAGS, true, true)).isSameInstanceAs(options);
 
     int flags = FLAG_LEFT_ALIGN | FLAG_SHOW_ALT_FORM | FLAG_SHOW_GROUPING | FLAG_SHOW_LEADING_ZEROS;
     FormatOptions filtered = options.filter(flags, true, false);

--- a/api/src/test/java/com/google/common/flogger/backend/SimpleMessageFormatterTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/SimpleMessageFormatterTest.java
@@ -57,7 +57,7 @@ public class SimpleMessageFormatterTest {
 
   @Test
   public void testToStringFormatsCorrectly() {
-    assertThat(SimpleMessageFormatter.toString("Hello World")).isSameAs("Hello World");
+    assertThat(SimpleMessageFormatter.toString("Hello World")).isSameInstanceAs("Hello World");
     assertThat(SimpleMessageFormatter.toString(10)).isEqualTo("10");
     assertThat(SimpleMessageFormatter.toString(false)).isEqualTo("false");
     // Not what you'd normally get from Object#toString() ...

--- a/api/src/test/java/com/google/common/flogger/backend/TagsTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/TagsTest.java
@@ -37,7 +37,7 @@ public class TagsTest {
 
   @Test
   public void testEmpty() {
-    assertThat(Tags.builder().build()).isSameAs(Tags.empty());
+    assertThat(Tags.builder().build()).isSameInstanceAs(Tags.empty());
   }
 
   @Test
@@ -100,9 +100,9 @@ public class TagsTest {
   public void testTagMerging_empty() {
     // It is important to not create new instances when merging.
     Tags tags = Tags.builder().addTag("foo").build();
-    assertThat(tags.merge(Tags.empty())).isSameAs(tags);
-    assertThat(Tags.empty().merge(tags)).isSameAs(tags);
-    assertThat(Tags.empty().merge(Tags.empty())).isSameAs(Tags.empty());
+    assertThat(tags.merge(Tags.empty())).isSameInstanceAs(tags);
+    assertThat(Tags.empty().merge(tags)).isSameInstanceAs(tags);
+    assertThat(Tags.empty().merge(Tags.empty())).isSameInstanceAs(Tags.empty());
   }
 
   @Test

--- a/api/src/test/java/com/google/common/flogger/backend/system/SimpleLogRecordTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/system/SimpleLogRecordTest.java
@@ -93,7 +93,7 @@ public class SimpleLogRecordTest {
 
     LogRecord record = SimpleLogRecord.create(data);
 
-    assertThat(record.getThrown()).isSameAs(cause);
+    assertThat(record.getThrown()).isSameInstanceAs(cause);
   }
 
   @Test

--- a/api/src/test/java/com/google/common/flogger/parameter/ParameterTest.java
+++ b/api/src/test/java/com/google/common/flogger/parameter/ParameterTest.java
@@ -63,7 +63,7 @@ public class ParameterTest {
   public void testGetOptions() throws ParseException {
     FormatOptions options = FormatOptions.parse("-2.2", 0, 4, false);
     Parameter p = new TestParameter(options, 0);
-    assertThat(p.getFormatOptions()).isSameAs(options);
+    assertThat(p.getFormatOptions()).isSameInstanceAs(options);
   }
 
   @Test

--- a/api/src/test/java/com/google/common/flogger/parameter/SimpleParameterTest.java
+++ b/api/src/test/java/com/google/common/flogger/parameter/SimpleParameterTest.java
@@ -37,7 +37,7 @@ public class SimpleParameterTest {
     for (FormatChar c : FormatChar.values()) {
       for (int n = 0; n < 10; n++) {
         assertThat(SimpleParameter.of(n, c, FormatOptions.getDefault()))
-            .isSameAs(SimpleParameter.of(n, c, FormatOptions.getDefault()));
+            .isSameInstanceAs(SimpleParameter.of(n, c, FormatOptions.getDefault()));
       }
     }
     // Different indices do not return the same instances.

--- a/api/src/test/java/com/google/common/flogger/testing/AssertingLogger.java
+++ b/api/src/test/java/com/google/common/flogger/testing/AssertingLogger.java
@@ -120,6 +120,6 @@ public class AssertingLogger extends Logger {
   }
 
   public void assertThrown(int index, Throwable thrown) {
-    assertThat(entries.get(index).thrown).isSameAs(thrown);
+    assertThat(entries.get(index).thrown).isSameInstanceAs(thrown);
   }
 }

--- a/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
@@ -79,7 +79,7 @@ public final class LogDataSubject extends Subject<LogDataSubject, LogData> {
     if (actual().getTemplateContext() != null) {
       actualArgs = Arrays.asList(actual().getArguments());
     }
-    check().that(actualArgs).containsExactly(args).inOrder();
+    check("getArguments()").that(actualArgs).containsExactly(args).inOrder();
   }
 
   /** Asserts that this log entry was forced. */

--- a/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
@@ -92,11 +92,11 @@ public final class MetadataSubject extends Subject<MetadataSubject, Metadata> {
   }
 
   public IterableSubject keys() {
-    return check().that(keyList());
+    return check("keys()").that(keyList());
   }
 
   public IterableSubject values() {
-    return check().that(valueList());
+    return check("values()").that(valueList());
   }
 }
 

--- a/log4j/src/test/java/com/google/common/flogger/backend/log4j/AssertingLogger.java
+++ b/log4j/src/test/java/com/google/common/flogger/backend/log4j/AssertingLogger.java
@@ -123,6 +123,6 @@ final class AssertingLogger extends Logger {
   }
 
   void assertThrown(int index, Throwable thrown) {
-    assertThat(entries.get(index).thrown).isSameAs(thrown);
+    assertThat(entries.get(index).thrown).isSameInstanceAs(thrown);
   }
 }

--- a/log4j/src/test/java/com/google/common/flogger/backend/log4j/SimpleLogEventTest.java
+++ b/log4j/src/test/java/com/google/common/flogger/backend/log4j/SimpleLogEventTest.java
@@ -100,7 +100,8 @@ public class SimpleLogEventTest {
     LogData data =
         FakeLogData.withPrintfStyle("Hello World").addMetadata(LogContext.Key.LOG_CAUSE, cause);
     SimpleLogEvent logEvent = newSimpleLogEvent(data);
-    assertThat(logEvent.asLoggingEvent().getThrowableInformation().getThrowable()).isSameAs(cause);
+    assertThat(logEvent.asLoggingEvent().getThrowableInformation().getThrowable())
+        .isSameInstanceAs(cause);
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate from containsAllIn to containsAtLeastElementsIn.

The two behave identically, and containsAllIn is being removed.

712d8cd04e00f2421ad01ae62e507e62d40bbead

-------

<p> Migrate from is(Not)SameAs to is(Not)SameInstanceAs.

They behave identically, and the old names are being removed.

Open-source note: The new methods are available in Truth as of version 0.44.

fb47867ae655a0588c67bc09fb985d32886dc5fa

-------

<p> Migrate Truth Subjects from no-arg check() to the overload that accepts a description.

The overload that accepts a description generally produces better failure messages:
- The first line of the message it produces is something like: "value of: myProto.getResponse()" (where "getResponse()" is taken from the provided description)
- The last line of the message it produces is something like: "myProto was: response: query was throttled" (the full value of myProto)
- And the existing text goes in between.

Additional motivation: We are deleting the no-arg overload externally (and probably internally thereafter).

9d149ec2b93443af600ca469b2f826802926e7c9