### PR TITLE
Moe Sync

### DIFF
--- a/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
@@ -65,85 +65,85 @@ public final class FormatOptionsSubject extends Subject<FormatOptionsSubject, Fo
 
   public void shouldUpperCase() {
     if (!actual().shouldUpperCase()) {
-      fail("should upper case");
+      failWithActual(simpleFact("expected to upper case"));
     }
   }
 
   public void shouldntUpperCase() {
     if (actual().shouldUpperCase()) {
-      fail("shouldn't upper case");
+      failWithActual(simpleFact("expected not to upper case"));
     }
   }
 
   public void shouldLeftAlign() {
     if (!actual().shouldLeftAlign()) {
-      fail("should left align");
+      failWithActual(simpleFact("expected to left align"));
     }
   }
 
   public void shouldntLeftAlign() {
     if (actual().shouldLeftAlign()) {
-      fail("shouldn't left align");
+      failWithActual(simpleFact("expected not to left align"));
     }
   }
 
   public void shouldShowAltForm() {
     if (!actual().shouldShowAltForm()) {
-      fail("should show alt form");
+      failWithActual(simpleFact("expected to show alt form"));
     }
   }
 
   public void shouldntShowAltForm() {
     if (actual().shouldShowAltForm()) {
-      fail("shouldn't show alt form");
+      failWithActual(simpleFact("expected not to show alt form"));
     }
   }
 
   public void shouldShowGrouping() {
     if (!actual().shouldShowGrouping()) {
-      fail("should show grouping");
+      failWithActual(simpleFact("expected to show grouping"));
     }
   }
 
   public void shouldntShowGrouping() {
     if (actual().shouldShowGrouping()) {
-      fail("shouldn't show grouping");
+      failWithActual(simpleFact("expected not to show grouping"));
     }
   }
 
   public void shouldShowLeadingZeros() {
     if (!actual().shouldShowLeadingZeros()) {
-      fail("should show leading zeros");
+      failWithActual(simpleFact("expected to show leading zeros"));
     }
   }
 
   public void shouldntShowLeadingZeros() {
     if (actual().shouldShowLeadingZeros()) {
-      fail("shouldn't show leading zeros");
+      failWithActual(simpleFact("expected not to show leading zeros"));
     }
   }
 
   public void shouldPrefixSpaceForPositiveValues() {
     if (!actual().shouldPrefixSpaceForPositiveValues()) {
-      fail("should prefix space for positive values");
+      failWithActual(simpleFact("expected to prefix space for positive values"));
     }
   }
 
   public void shouldntPrefixSpaceForPositiveValues() {
     if (actual().shouldPrefixSpaceForPositiveValues()) {
-      fail("shouldn't prefix space for positive values");
+      failWithActual(simpleFact("expected not to prefix space for positive values"));
     }
   }
 
   public void shouldPrefixPlusForPositiveValues() {
     if (!actual().shouldPrefixPlusForPositiveValues()) {
-      fail("should prefix plus for positive values");
+      failWithActual(simpleFact("expected to prefix plus for positive values"));
     }
   }
 
   public void shouldntPrefixPlusForPositiveValues() {
     if (actual().shouldPrefixPlusForPositiveValues()) {
-      fail("shouldn't prefix plus for positive values");
+      failWithActual(simpleFact("expected not to prefix plus for positive values"));
     }
   }
 

--- a/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
@@ -16,6 +16,7 @@
 
 package com.google.common.flogger.testing;
 
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertAbout;
 
 import com.google.common.collect.ImmutableList;
@@ -85,7 +86,7 @@ public final class LogDataSubject extends Subject<LogDataSubject, LogData> {
   /** Asserts that this log entry was forced. */
   public void wasForced() {
     if (!actual().wasForced()) {
-      fail("was forced");
+      failWithActual(simpleFact("expected to be forced"));
     }
   }
 }

--- a/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
@@ -68,10 +68,7 @@ public final class MetadataSubject extends Subject<MetadataSubject, Metadata> {
 
   public void hasSize(int expectedSize) {
     checkArgument(expectedSize >= 0, "expectedSize(%s) must be >= 0", expectedSize);
-    int actualSize = actual().size();
-    if (actualSize != expectedSize) {
-      failWithBadResults("has a size of", expectedSize, "is", actualSize);
-    }
+    check("size()").that(actual().size()).isEqualTo(expectedSize);
   }
 
   public <T> void containsUniqueEntry(MetadataKey<T> key, T value) {
@@ -79,10 +76,9 @@ public final class MetadataSubject extends Subject<MetadataSubject, Metadata> {
     checkNotNull(value, "value must not be null");
     T actual = actual().findValue(key);
     if (actual == null) {
-      fail("contained value for key", key);
-    } else if (!value.equals(actual)) {
-      failWithBadResults("contained mapping '" + key + "':", value, "was", actual);
+      failWithActual("expected to contain value for key", key);
     } else {
+      check("findValue(%s)", key).that(actual).isEqualTo(value);
       // The key must exist, so neither method will return -1.
       List<MetadataKey<?>> keys = keyList();
       if (keys.indexOf(key) != keys.lastIndexOf(key)) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate users from the old, deprecated Subject.fail* methods to the new Subject.fail* methods or, in some cases, to Subject.check.

Most of the changes in this CL were made manually.

I've tried to preserve all information (and of course behavior!), but the format and grammar of the messages does change. For example before-and-after messages, see the LSC doc.

In some of the CLs in this round (e.g., jscomp), I don't know a lot about the domain being tested, and the assertions are complex, so please let me know if my new phrasing is wrong or confusing.

Thanks again for your patience with all the Truth changes lately.

d9a31b5798fb5aa74c9c5677b4ea2bd18a18af30