### PR TITLE
Moe Sync

### DIFF
--- a/api/src/main/java/com/google/common/flogger/backend/Tags.java
+++ b/api/src/main/java/com/google/common/flogger/backend/Tags.java
@@ -235,6 +235,38 @@ public final class Tags {
     return EMPTY_TAGS;
   }
 
+  /**
+   * Returns a single tag without needing to use the builder API. Where multiple tags are needed,
+   * it is always better to use the builder directly.
+   */
+  public static Tags of(String name, String value) {
+    return builder().addTag(name, value).build();
+  }
+
+  /**
+   * Returns a single tag without needing to use the builder API. Where multiple tags are needed,
+   * it is always better to use the builder directly.
+   */
+  public static Tags of(String name, boolean value) {
+    return builder().addTag(name, value).build();
+  }
+
+  /**
+   * Returns a single tag without needing to use the builder API. Where multiple tags are needed,
+   * it is always better to use the builder directly.
+   */
+  public static Tags of(String name, long value) {
+    return builder().addTag(name, value).build();
+  }
+
+  /**
+   * Returns a single tag without needing to use the builder API. Where multiple tags are needed,
+   * it is always better to use the builder directly.
+   */
+  public static Tags of(String name, double value) {
+    return builder().addTag(name, value).build();
+  }
+
   private final SortedMap<String, SortedSet<Object>> map;
   private Integer hashCode = null;
   private String toString = null;

--- a/api/src/test/java/com/google/common/flogger/backend/SimpleMessageFormatterTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/SimpleMessageFormatterTest.java
@@ -21,7 +21,9 @@ import static com.google.common.flogger.backend.FormatOptions.UNSET;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.flogger.LogContext.Key;
+import com.google.common.flogger.LogSite;
 import com.google.common.flogger.MetadataKey;
+import com.google.common.flogger.backend.SimpleMessageFormatter.Option;
 import com.google.common.flogger.backend.SimpleMessageFormatter.SimpleLogHandler;
 import com.google.common.flogger.testing.FakeLogData;
 import java.io.IOException;
@@ -107,6 +109,16 @@ public class SimpleMessageFormatterTest {
   }
 
   @Test
+  public void testFormatWithOption() {
+    assertThat(logWithOption(Option.DEFAULT, "Hello World")).isEqualTo("Hello World");
+    assertThat(logWithOption(Option.WITH_LOG_SITE, "Hello World"))
+        .isEqualTo("com.google.FakeClass.fakeMethod:123 Hello World");
+    assertThat(logWithOptionInvalidLogSite(Option.DEFAULT, "Hello World")).isEqualTo("Hello World");
+    assertThat(logWithOptionInvalidLogSite(Option.WITH_LOG_SITE, "Hello World"))
+        .isEqualTo("Hello World");
+  }
+
+  @Test
   public void testToStringError() {
     Object arg = new Object() {
       @Override
@@ -144,6 +156,20 @@ public class SimpleMessageFormatterTest {
   private static String log(String message, Object... args) {
     SimpleLogHandler handler = getSimpleLogHandler();
     SimpleMessageFormatter.format(FakeLogData.withPrintfStyle(message, args), handler);
+    return handler.toString();
+  }
+
+  private static String logWithOption(Option option, String message, Object... args) {
+    SimpleLogHandler handler = getSimpleLogHandler();
+    SimpleMessageFormatter.format(FakeLogData.withPrintfStyle(message, args), handler, option);
+    return handler.toString();
+  }
+
+  private static String logWithOptionInvalidLogSite(Option option, String message, Object... args) {
+    SimpleLogHandler handler = getSimpleLogHandler();
+    FakeLogData fakeLogData = FakeLogData.withPrintfStyle(message, args);
+    fakeLogData.setLogSite(LogSite.INVALID);
+    SimpleMessageFormatter.format(fakeLogData, handler, option);
     return handler.toString();
   }
 

--- a/api/src/test/java/com/google/common/flogger/testing/FakeLogData.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FakeLogData.java
@@ -36,7 +36,7 @@ import java.util.logging.Level;
  * This helps decouple the testing of the backend from the frontend, and makes the intent of the
  * tests clearer.
  */
-public class FakeLogData implements LogData {
+public final class FakeLogData implements LogData {
   public static final String FAKE_LOGGER_NAME = "com.google.LoggerName";
 
   public static final String FAKE_LOGGING_CLASS = "com.google.FakeClass";
@@ -70,6 +70,7 @@ public class FakeLogData implements LogData {
   private Object literalArgument = null;
   private long timestampNanos = 0L;
   private FakeMetadata metadata = new FakeMetadata();
+  private LogSite logSite = FAKE_LOG_SITE;
 
   private FakeLogData(Object literalArgument) {
     this.literalArgument = literalArgument;
@@ -88,6 +89,11 @@ public class FakeLogData implements LogData {
 
   public FakeLogData setLevel(Level level) {
     this.level = level;
+    return this;
+  }
+
+  public FakeLogData setLogSite(LogSite logSite) {
+    this.logSite = logSite;
     return this;
   }
 
@@ -119,7 +125,7 @@ public class FakeLogData implements LogData {
 
   @Override
   public LogSite getLogSite() {
-    return FAKE_LOG_SITE;
+    return logSite;
   }
 
   @Override

--- a/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
@@ -39,122 +39,125 @@ public final class FormatOptionsSubject extends Subject<FormatOptionsSubject, Fo
   private static final Subject.Factory<FormatOptionsSubject, FormatOptions> FORMAT_OPTIONS_FACTORY =
       FormatOptionsSubject::new;
 
+  private final FormatOptions actual;
+
   private FormatOptionsSubject(FailureMetadata failureMetadata, @Nullable FormatOptions subject) {
     super(failureMetadata, subject);
+    this.actual = subject;
   }
 
   public void isDefault() {
-    if (!actual().isDefault()) {
+    if (!actual.isDefault()) {
       failWithActual(simpleFact("expected to be default"));
     }
   }
 
   public void hasPrecision(int precision) {
-    check("getPrecision()").that(actual().getPrecision()).isEqualTo(precision);
+    check("getPrecision()").that(actual.getPrecision()).isEqualTo(precision);
   }
 
   public void hasWidth(int width) {
-    check("getWidth()").that(actual().getWidth()).isEqualTo(width);
+    check("getWidth()").that(actual.getWidth()).isEqualTo(width);
   }
 
   public void hasNoFlags() {
-    if (actual().getFlags() != 0) {
+    if (actual.getFlags() != 0) {
       failWithActual(simpleFact("expected to have no flags"));
     }
   }
 
   public void shouldUpperCase() {
-    if (!actual().shouldUpperCase()) {
+    if (!actual.shouldUpperCase()) {
       failWithActual(simpleFact("expected to upper case"));
     }
   }
 
   public void shouldntUpperCase() {
-    if (actual().shouldUpperCase()) {
+    if (actual.shouldUpperCase()) {
       failWithActual(simpleFact("expected not to upper case"));
     }
   }
 
   public void shouldLeftAlign() {
-    if (!actual().shouldLeftAlign()) {
+    if (!actual.shouldLeftAlign()) {
       failWithActual(simpleFact("expected to left align"));
     }
   }
 
   public void shouldntLeftAlign() {
-    if (actual().shouldLeftAlign()) {
+    if (actual.shouldLeftAlign()) {
       failWithActual(simpleFact("expected not to left align"));
     }
   }
 
   public void shouldShowAltForm() {
-    if (!actual().shouldShowAltForm()) {
+    if (!actual.shouldShowAltForm()) {
       failWithActual(simpleFact("expected to show alt form"));
     }
   }
 
   public void shouldntShowAltForm() {
-    if (actual().shouldShowAltForm()) {
+    if (actual.shouldShowAltForm()) {
       failWithActual(simpleFact("expected not to show alt form"));
     }
   }
 
   public void shouldShowGrouping() {
-    if (!actual().shouldShowGrouping()) {
+    if (!actual.shouldShowGrouping()) {
       failWithActual(simpleFact("expected to show grouping"));
     }
   }
 
   public void shouldntShowGrouping() {
-    if (actual().shouldShowGrouping()) {
+    if (actual.shouldShowGrouping()) {
       failWithActual(simpleFact("expected not to show grouping"));
     }
   }
 
   public void shouldShowLeadingZeros() {
-    if (!actual().shouldShowLeadingZeros()) {
+    if (!actual.shouldShowLeadingZeros()) {
       failWithActual(simpleFact("expected to show leading zeros"));
     }
   }
 
   public void shouldntShowLeadingZeros() {
-    if (actual().shouldShowLeadingZeros()) {
+    if (actual.shouldShowLeadingZeros()) {
       failWithActual(simpleFact("expected not to show leading zeros"));
     }
   }
 
   public void shouldPrefixSpaceForPositiveValues() {
-    if (!actual().shouldPrefixSpaceForPositiveValues()) {
+    if (!actual.shouldPrefixSpaceForPositiveValues()) {
       failWithActual(simpleFact("expected to prefix space for positive values"));
     }
   }
 
   public void shouldntPrefixSpaceForPositiveValues() {
-    if (actual().shouldPrefixSpaceForPositiveValues()) {
+    if (actual.shouldPrefixSpaceForPositiveValues()) {
       failWithActual(simpleFact("expected not to prefix space for positive values"));
     }
   }
 
   public void shouldPrefixPlusForPositiveValues() {
-    if (!actual().shouldPrefixPlusForPositiveValues()) {
+    if (!actual.shouldPrefixPlusForPositiveValues()) {
       failWithActual(simpleFact("expected to prefix plus for positive values"));
     }
   }
 
   public void shouldntPrefixPlusForPositiveValues() {
-    if (actual().shouldPrefixPlusForPositiveValues()) {
+    if (actual.shouldPrefixPlusForPositiveValues()) {
       failWithActual(simpleFact("expected not to prefix plus for positive values"));
     }
   }
 
   public void areValidFor(FormatChar formatChar) {
-    if (!actual().areValidFor(formatChar)) {
+    if (!actual.areValidFor(formatChar)) {
       failWithActual("expected to be valid for", formatChar);
     }
   }
 
   public void areNotValidFor(FormatChar formatChar) {
-    if (actual().areValidFor(formatChar)) {
+    if (actual.areValidFor(formatChar)) {
       failWithActual("expected not to be valid for", formatChar);
     }
   }

--- a/api/src/test/java/com/google/common/flogger/testing/FormatTypeSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatTypeSubject.java
@@ -38,33 +38,36 @@ public final class FormatTypeSubject extends Subject<FormatTypeSubject, FormatTy
   private static final Subject.Factory<FormatTypeSubject, FormatType> FORMAT_TYPE_SUBJECT_FACTORY =
       FormatTypeSubject::new;
 
+  private final FormatType actual;
+
   private FormatTypeSubject(FailureMetadata failureMetadata, @Nullable FormatType subject) {
     super(failureMetadata, subject);
+    this.actual = subject;
   }
 
   public void canFormat(Object arg) {
-    assertWithMessage("Unable to format " + arg + " using " + getSubject())
-        .that(getSubject().canFormat(arg))
+    assertWithMessage("Unable to format " + arg + " using " + actual)
+        .that(actual.canFormat(arg))
         .isTrue();
   }
 
   public void cannotFormat(Object arg) {
-    assertWithMessage("Expected error when formatting " + arg + " using " + getSubject())
-        .that(getSubject().canFormat(arg))
+    assertWithMessage("Expected error when formatting " + arg + " using " + actual)
+        .that(actual.canFormat(arg))
         .isFalse();
   }
 
   public void isNumeric() {
     check("isNumeric()")
-        .withMessage("Expected " + getSubject() + " to be numeric but wasn't")
-        .that(getSubject().isNumeric())
+        .withMessage("Expected " + actual + " to be numeric but wasn't")
+        .that(actual.isNumeric())
         .isTrue();
   }
 
   public void isNotNumeric() {
     check("isNumeric()")
-        .withMessage("Expected " + getSubject() + " to not be numeric but was")
-        .that(getSubject().isNumeric())
+        .withMessage("Expected " + actual + " to not be numeric but was")
+        .that(actual.isNumeric())
         .isFalse();
   }
 }

--- a/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
@@ -44,13 +44,16 @@ public final class LogDataSubject extends Subject<LogDataSubject, LogData> {
     return assertAbout(logData()).that(logData);
   }
 
+  private final LogData actual;
+
   private LogDataSubject(FailureMetadata failureMetadata, @Nullable LogData subject) {
     super(failureMetadata, subject);
+    this.actual = subject;
   }
 
   /** Asserts about the metadata of this log entry. */
   public MetadataSubject metadata() {
-    return check("getMetadata()").about(MetadataSubject.metadata()).that(actual().getMetadata());
+    return check("getMetadata()").about(MetadataSubject.metadata()).that(actual.getMetadata());
   }
 
   /**
@@ -59,13 +62,13 @@ public final class LogDataSubject extends Subject<LogDataSubject, LogData> {
    * {@code assertLogData(e).hasMessage(value);}.
    */
   public void hasMessage(Object messageOrLiteral) {
-    if (actual().getTemplateContext() == null) {
+    if (actual.getTemplateContext() == null) {
       // Expect literal argument (possibly null).
-      check("getLiteralArgument()").that(actual().getLiteralArgument()).isEqualTo(messageOrLiteral);
+      check("getLiteralArgument()").that(actual.getLiteralArgument()).isEqualTo(messageOrLiteral);
     } else {
       // Expect message string (non null).
       check("getTemplateContext().getMessage()")
-          .that(actual().getTemplateContext().getMessage())
+          .that(actual.getTemplateContext().getMessage())
           .isEqualTo(messageOrLiteral);
     }
   }
@@ -77,15 +80,15 @@ public final class LogDataSubject extends Subject<LogDataSubject, LogData> {
    */
   public void hasArguments(Object... args) {
     List<Object> actualArgs = ImmutableList.of();
-    if (actual().getTemplateContext() != null) {
-      actualArgs = Arrays.asList(actual().getArguments());
+    if (actual.getTemplateContext() != null) {
+      actualArgs = Arrays.asList(actual.getArguments());
     }
     check("getArguments()").that(actualArgs).containsExactly(args).inOrder();
   }
 
   /** Asserts that this log entry was forced. */
   public void wasForced() {
-    if (!actual().wasForced()) {
+    if (!actual.wasForced()) {
       failWithActual(simpleFact("expected to be forced"));
     }
   }

--- a/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
@@ -44,12 +44,15 @@ public final class MetadataSubject extends Subject<MetadataSubject, Metadata> {
     return assertAbout(metadata()).that(metadata);
   }
 
+  private final Metadata actual;
+
   private MetadataSubject(FailureMetadata failureMetadata, @Nullable Metadata subject) {
     super(failureMetadata, subject);
+    this.actual = subject;
   }
 
   private List<MetadataKey<?>> keyList() {
-    Metadata metadata = actual();
+    Metadata metadata = actual;
     List<MetadataKey<?>> keys = new ArrayList<>();
     for (int n = 0; n < metadata.size(); n++) {
       keys.add(metadata.getKey(n));
@@ -58,7 +61,7 @@ public final class MetadataSubject extends Subject<MetadataSubject, Metadata> {
   }
 
   private List<Object> valueList() {
-    Metadata metadata = actual();
+    Metadata metadata = actual;
     List<Object> values = new ArrayList<>();
     for (int n = 0; n < metadata.size(); n++) {
       values.add(metadata.getValue(n));
@@ -68,13 +71,13 @@ public final class MetadataSubject extends Subject<MetadataSubject, Metadata> {
 
   public void hasSize(int expectedSize) {
     checkArgument(expectedSize >= 0, "expectedSize(%s) must be >= 0", expectedSize);
-    check("size()").that(actual().size()).isEqualTo(expectedSize);
+    check("size()").that(actual.size()).isEqualTo(expectedSize);
   }
 
   public <T> void containsUniqueEntry(MetadataKey<T> key, T value) {
     checkNotNull(key, "key must not be null");
     checkNotNull(value, "value must not be null");
-    T actual = actual().findValue(key);
+    T actual = this.actual.findValue(key);
     if (actual == null) {
       failWithActual("expected to contain value for key", key);
     } else {

--- a/docs/best_practice.md
+++ b/docs/best_practice.md
@@ -178,7 +178,7 @@ The following code fails with a `NullPointerException`:
 
 ```java
 private static final Data data = initStaticData();
-private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
 private static Data initStaticData() {
   logger.atInfo().log("Initializing static data");


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Internal Change

28ed50832b6b44497a5185f9c88851bce1492daf

-------

<p> Instead of calling Subject.actual(), store the actual value in a field, and read that.

actual() is being removed.

bd6993baf01ff5b1bb7658010088e0aaf649dcbd

-------

<p> Update example to use GoogleLogger rather than FluentLogger.

e855f814ffe926d69d1bcb12c5179a9de57d0b9d

-------

<p> Removed hard check for the implicit contex, rather than failing.

This will enable the methods which accept a trace context to be removed from the API (*), making the API agnostic to the underlying trace mechanism and allowing it to be switched for gRPC context.

Added a return flag to indicate if the operation could be performed or not. Sadly attempting to add logging didn't work (cyclic deps for logger initialisation). If it's felt to be important, I can always just use JDK logging :/

* - The _only_ user of the version that accepts a context is doing it so they can pre-check for implicit contexts.

This doesn't affect any open-source APIs.

RELNOTES=N/A

7c1288a6171c1aec814ac4544b10c32ff21274ec