### PR TITLE
Update dependency on google_bazel_common

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,8 +16,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "google_bazel_common",
-    strip_prefix = "bazel-common-f3dc1a775d21f74fc6f4bbcf076b8af2f6261a69",
-    urls = ["https://github.com/google/bazel-common/archive/f3dc1a775d21f74fc6f4bbcf076b8af2f6261a69.zip"],
+    strip_prefix = "bazel-common-597824dfc652477e08f229707fa167f595cf7060",
+    urls = ["https://github.com/google/bazel-common/archive/597824dfc652477e08f229707fa167f595cf7060.zip"],
+    sha256 = "1e077183d361d819b75f881e0d087a28b7eca12e10f32c9c06ce366cb1246256",
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")


### PR DESCRIPTION
With this change, Flogger can build with the upcoming Bazel 0.27.