### PR TITLE
Moe Sync

### DIFF
--- a/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  *
  * @author Kurt Alfred Kluever (kak@google.com)
  */
-public final class FormatOptionsSubject extends Subject<FormatOptionsSubject, FormatOptions> {
+public final class FormatOptionsSubject extends Subject {
 
   public static FormatOptionsSubject assertThat(@Nullable FormatOptions formatOptions) {
     return assertAbout(FormatOptionsSubject.FORMAT_OPTIONS_FACTORY).that(formatOptions);

--- a/api/src/test/java/com/google/common/flogger/testing/FormatTypeSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatTypeSubject.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  *
  * @author Kurt Alfred Kluever (kak@google.com)
  */
-public final class FormatTypeSubject extends Subject<FormatTypeSubject, FormatType> {
+public final class FormatTypeSubject extends Subject {
 
   public static FormatTypeSubject assertThat(@Nullable FormatType formatType) {
     return assertAbout(FormatTypeSubject.FORMAT_TYPE_SUBJECT_FACTORY).that(formatType);

--- a/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
@@ -28,11 +28,9 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 
-/**
- * A <a href="https://github.com/google/truth">Truth</a> subject for {@link LogData}.
- */
+/** A <a href="https://github.com/google/truth">Truth</a> subject for {@link LogData}. */
 @CheckReturnValue
-public final class LogDataSubject extends Subject<LogDataSubject, LogData> {
+public final class LogDataSubject extends Subject {
   private static final Subject.Factory<LogDataSubject, LogData> LOG_DATA_SUBJECT_FACTORY =
       LogDataSubject::new;
 

--- a/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
@@ -29,10 +29,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 
-/**
- * A <a href="https://github.com/google/truth">Truth</a> subject for {@link Metadata}.
- */
-public final class MetadataSubject extends Subject<MetadataSubject, Metadata> {
+/** A <a href="https://github.com/google/truth">Truth</a> subject for {@link Metadata}. */
+public final class MetadataSubject extends Subject {
   private static final Subject.Factory<MetadataSubject, Metadata> METADATA_SUBJECT_FACTORY =
       MetadataSubject::new;
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update to Truth 0.45, and address deprecations.

Renames may include:
- containsAllOf => containsAtLeast
- containsAllIn => containsAtLeastElementsIn
- isSameAs => isSameInstanceAs
- isOrdered => isInOrder
- isStrictlyOrdered => isInStrictOrder

The other major change is to change custom subjects to extend raw Subject instead of supplying type parameters. The type parameters are being removed from Subject. This CL will temporarily produce rawtypes warnings, which will go away when I remove the type parameters (as soon as this batch of CLs is submitted).

Some CLs in this batch also migrate calls away from actualAsString(). Its literal replacement is `"<" + actual + ">"` (unless an object overrides actualCustomStringRepresentation()), but usually I've made a larger change, such as switching from an old-style "Not true that..." failure message to one generated with the Fact API. In that case, the new code usually contains a direct reference to this.actual (a field that I occasionally had to create). Another larger change I sometimes made is to switch from a manual check-and-fail approach to instead use check(...). And sometimes I just remove a withMessage() call that's no longer necessary now that the code uses check(...), or I introduce a check(...) call. (An assertion made with check(...) automatically includes the actual value from the original subject, so there's no need to set it again with withMessage().)

Finally, there's one CL in this batch in which I migrate a Correspondence subclass to instead use Correspondence.from.

d9382ca5683c7c8330120c7453c1301ec5360cde