### PR TITLE
Add support for custom level on forced #95

### DIFF
--- a/api/src/main/java/com/google/common/flogger/FluentLogger.java
+++ b/api/src/main/java/com/google/common/flogger/FluentLogger.java
@@ -80,6 +80,12 @@ public final class FluentLogger extends AbstractLogger<FluentLogger.Api> {
   public Api at(Level level) {
     boolean isLoggable = isLoggable(level);
     boolean isForced = Platform.shouldForceLogging(getName(), level, isLoggable);
+    if (!isLoggable && isForced) {
+      Level forceLoggingLevel = Platform.getForceLoggingLevelOnLevelUnable();
+      if (forceLoggingLevel != null) {
+        level = forceLoggingLevel;
+      }
+    }
     return (isLoggable || isForced) ? new Context(level, isForced) : NO_OP;
   }
 

--- a/api/src/main/java/com/google/common/flogger/backend/Platform.java
+++ b/api/src/main/java/com/google/common/flogger/backend/Platform.java
@@ -180,6 +180,14 @@ public abstract class Platform {
     return false;
   }
 
+  public static Level getForceLoggingLevelOnLevelUnable() {
+    return LazyHolder.INSTANCE.getForceLoggingLevelOnLevelUnableImpl();
+  }
+
+  protected Level getForceLoggingLevelOnLevelUnableImpl() {
+    return null;
+  }
+
   public static Tags getInjectedTags() {
     return LazyHolder.INSTANCE.getInjectedTagsImpl();
   }

--- a/api/src/main/java/com/google/common/flogger/backend/system/DefaultPlatform.java
+++ b/api/src/main/java/com/google/common/flogger/backend/system/DefaultPlatform.java
@@ -94,6 +94,11 @@ public class DefaultPlatform extends Platform {
   }
 
   @Override
+  protected Level getForceLoggingLevelOnLevelUnableImpl() {
+    return context.getForceLoggingLevelOnLevelUnable();
+  }
+
+  @Override
   protected Tags getInjectedTagsImpl() {
     return context.getTags();
   }

--- a/api/src/main/java/com/google/common/flogger/backend/system/EmptyLoggingContext.java
+++ b/api/src/main/java/com/google/common/flogger/backend/system/EmptyLoggingContext.java
@@ -36,6 +36,11 @@ public final class EmptyLoggingContext extends LoggingContext {
   }
 
   @Override
+  public Level getForceLoggingLevelOnLevelUnable() {
+    return null;
+  }
+
+  @Override
   public Tags getTags() {
     return Tags.empty();
   }

--- a/api/src/main/java/com/google/common/flogger/backend/system/LoggingContext.java
+++ b/api/src/main/java/com/google/common/flogger/backend/system/LoggingContext.java
@@ -54,6 +54,13 @@ public abstract class LoggingContext {
       String loggerName, Level level, boolean isEnabledByLevel);
 
   /**
+   * Returns new Level, try to make backend log statement enabled. When {@code isEnabledByLevel} is false and {@link #shouldForceLogging(String, Level, boolean)} returns true.
+   *
+   * @return new Level, or null to use the original level.
+   */
+  public abstract Level getForceLoggingLevelOnLevelUnable();
+
+  /**
    * Returns a set of tags to be added to a log statement. These tags can be used to provide
    * additional contextual metadata to log statements (e.g. request IDs).
    *


### PR DESCRIPTION
Try to acomplish [#95 ](https://github.com/google/flogger/issues/95)

A new abstract method (getForceLoggingLevelOnLevelUnable) was added in LoggingContext.java, to customize force logging level.