### PR TITLE
Moe Sync

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -66,6 +66,7 @@ java_library(
         ":platform_provider",
         ":stack",
         ":tags",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
         "@google_bazel_common//third_party/java/error_prone:annotations",
         "@google_bazel_common//third_party/java/jsr305_annotations",
     ],
@@ -151,8 +152,8 @@ java_library(
     javacopts = ["-source 1.6 -target 1.6"],
     deps = [
         ":checks",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
         "@google_bazel_common//third_party/java/error_prone:annotations",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
     ],
 )
 
@@ -164,7 +165,7 @@ java_library(
     javacopts = ["-source 1.6 -target 1.6"],
     deps = [
         ":checks",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
     ],
 )
 
@@ -177,8 +178,8 @@ java_library(
     deps = [
         ":api",
         ":checks",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
         "@google_bazel_common//third_party/java/error_prone:annotations",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
     ],
 )
 
@@ -188,10 +189,7 @@ java_library(
     name = "stack",
     srcs = STACK_SRCS,
     javacopts = ["-source 1.6 -target 1.6"],
-    deps = [
-        "@google_bazel_common//third_party/java/error_prone:annotations",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
-    ],
+    deps = ["@google_bazel_common//third_party/java/checker_framework_annotations"],
 )
 
 # A separate library for exposing just the 'LogSite' class. This is exported as
@@ -202,8 +200,8 @@ java_library(
     javacopts = ["-source 1.6 -target 1.6"],
     deps = [
         ":checks",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
         "@google_bazel_common//third_party/java/error_prone:annotations",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
     ],
 )
 
@@ -216,12 +214,7 @@ java_library(
     srcs = LOG_SITE_HELPER_SRCS,
     javacopts = ["-source 1.6 -target 1.6"],
     exports = [":log_site"],
-    deps = [
-        ":api",
-        ":log_site",
-        "@google_bazel_common//third_party/java/error_prone:annotations",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
-    ],
+    deps = [":api"],
 )
 
 # Core library to implement a JDK compatible backend for Flogger.
@@ -235,8 +228,7 @@ java_library(
     deps = [
         ":api",
         ":checks",
-        ":log_site",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
     ],
 )
 
@@ -270,10 +262,9 @@ java_library(
     deps = [
         ":api",
         ":checks",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
         "@google_bazel_common//third_party/java/error_prone:annotations",
         "@google_bazel_common//third_party/java/guava",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
-        "@google_bazel_common//third_party/java/junit",
         "@google_bazel_common//third_party/java/truth",
     ],
 )
@@ -349,6 +340,7 @@ gen_java_tests(
         ":system_backend",
         ":testing",
         "@google_bazel_common//third_party/java/auto:service",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
         "@google_bazel_common//third_party/java/guava",
         "@google_bazel_common//third_party/java/guava:testlib",
         "@google_bazel_common//third_party/java/jsr305_annotations",

--- a/api/src/main/java/com/google/common/flogger/LazyArg.java
+++ b/api/src/main/java/com/google/common/flogger/LazyArg.java
@@ -16,7 +16,7 @@
 
 package com.google.common.flogger;
 
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Functional interface for allowing lazily evaluated arguments to be supplied to Flogger. This
@@ -33,6 +33,6 @@ public interface LazyArg<T> {
    * determined that logging will occur, and the returned value is used in place of the {@code
    * LazyArg} instance that was passed into the log statement.
    */
-  @Nullable
+  @NullableDecl
   T evaluate();
 }

--- a/api/src/main/java/com/google/common/flogger/LogContext.java
+++ b/api/src/main/java/com/google/common/flogger/LogContext.java
@@ -31,7 +31,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * The base context for a logging statement, which implements the base logging API.
@@ -186,7 +186,7 @@ public abstract class LogContext<
     }
 
     @Override
-    @Nullable
+    @NullableDecl
     public <T> T findValue(MetadataKey<T> key) {
       int index = indexOf(key);
       return index != -1 ? key.cast(keyValuePairs[(2 * index) + 1]) : null;
@@ -452,7 +452,7 @@ public abstract class LogContext<
    * <p>Implementations of this method must always call {@code super.postProcess()} first with the
    * given log site key, such as:
    *
-   * <pre>{@code protected boolean postProcess(@Nullable LogSiteKey logSiteKey) {
+   * <pre>{@code protected boolean postProcess(@NullableDecl LogSiteKey logSiteKey) {
    *   if (!super.postProcess(logSiteKey)) {
    *     return false;
    *   }
@@ -472,7 +472,7 @@ public abstract class LogContext<
    * @param logSiteKey used to lookup persistent, per log statement, state.
    * @return true if the logging backend should be invoked to output the current log statement.
    */
-  protected boolean postProcess(@Nullable LogSiteKey logSiteKey) {
+  protected boolean postProcess(@NullableDecl LogSiteKey logSiteKey) {
     if (metadata != null && logSiteKey != null) {
       // This code still gets reached if a "cause" was set, but as that's far more likely than any
       // other metadata that might suppress logging, it's not worth any more "early out" checks.
@@ -584,7 +584,7 @@ public abstract class LogContext<
       String internalClassName,
       String methodName,
       int encodedLineNumber,
-      @Nullable String sourceFileName) {
+      @NullableDecl String sourceFileName) {
     return withInjectedLogSite(
         LogSite.injectedLogSite(internalClassName, methodName, encodedLineNumber, sourceFileName));
   }
@@ -601,7 +601,7 @@ public abstract class LogContext<
   }
 
   @Override
-  public final <T> API with(MetadataKey<T> key, @Nullable T value) {
+  public final <T> API with(MetadataKey<T> key, @NullableDecl T value) {
     // Null keys are always bad (even if the value is also null). This is one of the few places
     // where the logger API will throw a runtime exception (and as such it's important to ensure
     // the NoOp implementation also does the check). The reasoning for this is that the metadata
@@ -680,125 +680,125 @@ public abstract class LogContext<
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1) {
+  public final void log(String message, @NullableDecl Object p1) {
     if (shouldLog()) logImpl(message, p1);
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, @Nullable Object p2) {
+  public final void log(String message, @NullableDecl Object p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
   public final void log(
-      String message, @Nullable Object p1, @Nullable Object p2, @Nullable Object p3) {
+      String message, @NullableDecl Object p1, @NullableDecl Object p2, @NullableDecl Object p3) {
     if (shouldLog()) logImpl(message, p1, p2, p3);
   }
 
   @Override
   public final void log(
       String message,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4) {
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4) {
     if (shouldLog()) logImpl(message, p1, p2, p3, p4);
   }
 
   @Override
   public final void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5) {
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5) {
     if (shouldLog()) logImpl(msg, p1, p2, p3, p4, p5);
   }
 
   @Override
   public final void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6) {
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6) {
     if (shouldLog()) logImpl(msg, p1, p2, p3, p4, p5, p6);
   }
 
   @Override
   public final void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7) {
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7) {
     if (shouldLog()) logImpl(msg, p1, p2, p3, p4, p5, p6, p7);
   }
 
   @Override
   public final void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7,
-      @Nullable Object p8) {
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7,
+      @NullableDecl Object p8) {
     if (shouldLog()) logImpl(msg, p1, p2, p3, p4, p5, p6, p7, p8);
   }
 
   @Override
   public final void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7,
-      @Nullable Object p8,
-      @Nullable Object p9) {
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7,
+      @NullableDecl Object p8,
+      @NullableDecl Object p9) {
     if (shouldLog()) logImpl(msg, p1, p2, p3, p4, p5, p6, p7, p8, p9);
   }
 
   @Override
   public final void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7,
-      @Nullable Object p8,
-      @Nullable Object p9,
-      @Nullable Object p10) {
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7,
+      @NullableDecl Object p8,
+      @NullableDecl Object p9,
+      @NullableDecl Object p10) {
     if (shouldLog()) logImpl(msg, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
   }
 
   @Override
   public final void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7,
-      @Nullable Object p8,
-      @Nullable Object p9,
-      @Nullable Object p10,
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7,
+      @NullableDecl Object p8,
+      @NullableDecl Object p9,
+      @NullableDecl Object p10,
       Object... rest) {
     if (shouldLog()) {
       // Manually create a new varargs array and copy the parameters in.
@@ -844,82 +844,82 @@ public abstract class LogContext<
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, boolean p2) {
+  public final void log(String message, @NullableDecl Object p1, boolean p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, char p2) {
+  public final void log(String message, @NullableDecl Object p1, char p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, byte p2) {
+  public final void log(String message, @NullableDecl Object p1, byte p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, short p2) {
+  public final void log(String message, @NullableDecl Object p1, short p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, int p2) {
+  public final void log(String message, @NullableDecl Object p1, int p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, long p2) {
+  public final void log(String message, @NullableDecl Object p1, long p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, float p2) {
+  public final void log(String message, @NullableDecl Object p1, float p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, @Nullable Object p1, double p2) {
+  public final void log(String message, @NullableDecl Object p1, double p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, boolean p1, @Nullable Object p2) {
+  public final void log(String message, boolean p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, char p1, @Nullable Object p2) {
+  public final void log(String message, char p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, byte p1, @Nullable Object p2) {
+  public final void log(String message, byte p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, short p1, @Nullable Object p2) {
+  public final void log(String message, short p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, int p1, @Nullable Object p2) {
+  public final void log(String message, int p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, long p1, @Nullable Object p2) {
+  public final void log(String message, long p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, float p1, @Nullable Object p2) {
+  public final void log(String message, float p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 
   @Override
-  public final void log(String message, double p1, @Nullable Object p2) {
+  public final void log(String message, double p1, @NullableDecl Object p2) {
     if (shouldLog()) logImpl(message, p1, p2);
   }
 

--- a/api/src/main/java/com/google/common/flogger/LogSite.java
+++ b/api/src/main/java/com/google/common/flogger/LogSite.java
@@ -19,7 +19,7 @@ package com.google.common.flogger;
 import static com.google.common.flogger.util.Checks.checkNotNull;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A value type which representing the location of a single log statement. This class is similar to
@@ -144,7 +144,7 @@ public abstract class LogSite implements LogSiteKey {
       String internalClassName,
       String methodName,
       int encodedLineNumber,
-      @Nullable String sourceFileName) {
+      @NullableDecl String sourceFileName) {
     return new InjectedLogSite(internalClassName, methodName, encodedLineNumber, sourceFileName);
   }
 

--- a/api/src/main/java/com/google/common/flogger/LogSiteStackTrace.java
+++ b/api/src/main/java/com/google/common/flogger/LogSiteStackTrace.java
@@ -16,7 +16,7 @@
 
 package com.google.common.flogger;
 
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A synthetic exception which can be attached to log statements when additional stack trace
@@ -36,7 +36,7 @@ public final class LogSiteStackTrace extends Exception {
    * @param syntheticStackTrace the synthetic stack trace starting at the log statement.
    */
   LogSiteStackTrace(
-      @Nullable Throwable cause, StackSize stackSize, StackTraceElement[] syntheticStackTrace) {
+      @NullableDecl Throwable cause, StackSize stackSize, StackTraceElement[] syntheticStackTrace) {
     super(stackSize.toString(), cause);
     // This takes a defensive copy, but there's no way around that. Note that we cannot override
     // getStackTrace() to avoid a defensive copy because that breaks stack trace formatting

--- a/api/src/main/java/com/google/common/flogger/LoggerConfig.java
+++ b/api/src/main/java/com/google/common/flogger/LoggerConfig.java
@@ -27,7 +27,7 @@ import java.util.logging.Filter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * An adapter for the configuration specific aspects of a JDK logger which retains a strong
@@ -140,35 +140,35 @@ public final class LoggerConfig {
   }
 
   /** See {@link Logger#getResourceBundle()}. */
-  @Nullable
+  @NullableDecl
   public ResourceBundle getResourceBundle() {
     return logger.getResourceBundle();
   }
 
   /** See {@link Logger#getResourceBundleName()}. */
-  @Nullable
+  @NullableDecl
   public String getResourceBundleName() {
     return logger.getResourceBundleName();
   }
 
   /** See {@link Logger#setFilter(Filter)}. */
-  public void setFilter(@Nullable Filter newFilter) throws SecurityException {
+  public void setFilter(@NullableDecl Filter newFilter) throws SecurityException {
     logger.setFilter(newFilter);
   }
 
   /** See {@link Logger#getFilter()}. */
-  @Nullable
+  @NullableDecl
   public Filter getFilter() {
     return logger.getFilter();
   }
 
   /** See {@link Logger#setLevel(Level)}. */
-  public void setLevel(@Nullable Level newLevel) throws SecurityException {
+  public void setLevel(@NullableDecl Level newLevel) throws SecurityException {
     logger.setLevel(newLevel);
   }
 
   /** See {@link Logger#getLevel()}. */
-  @Nullable
+  @NullableDecl
   public Level getLevel() {
     return logger.getLevel();
   }
@@ -206,7 +206,7 @@ public final class LoggerConfig {
   }
 
   /** See {@link Logger#getParent()}. */
-  @Nullable
+  @NullableDecl
   public Logger getParent() {
     return logger.getParent();
   }

--- a/api/src/main/java/com/google/common/flogger/LoggingApi.java
+++ b/api/src/main/java/com/google/common/flogger/LoggingApi.java
@@ -20,7 +20,7 @@ import static com.google.common.flogger.util.Checks.checkNotNull;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * The basic logging API. An implementation of this API (or an extension of it) will be
@@ -53,7 +53,7 @@ public interface LoggingApi<API extends LoggingApi<API>> {
    * If this method is called multiple times for a single log statement, the last invocation will
    * take precedence.
    */
-  API withCause(@Nullable Throwable cause);
+  API withCause(@NullableDecl Throwable cause);
 
   /**
    * Modifies the current log statement to be emitted only one-in-N times that it is invoked. The
@@ -169,7 +169,7 @@ public interface LoggingApi<API extends LoggingApi<API>> {
    * @throws NullPointerException if the given key is null
    * @see MetadataKey
    */
-  <T> API with(MetadataKey<T> key, @Nullable T value);
+  <T> API with(MetadataKey<T> key, @NullableDecl T value);
 
   /**
    * Sets the log site for the current log statement. Explicit log site injection is very rarely
@@ -239,7 +239,7 @@ public interface LoggingApi<API extends LoggingApi<API>> {
       String internalClassName,
       String methodName,
       int encodedLineNumber,
-      @Nullable String sourceFileName);
+      @NullableDecl String sourceFileName);
 
   /**
    * Returns true if logging is enabled at the level implied for this API, according to the current
@@ -277,19 +277,6 @@ public interface LoggingApi<API extends LoggingApi<API>> {
   boolean isEnabled();
 
   /**
-   * Terminal log statement when a message is not required. A {@code log} method must terminate all
-   * fluent logging chains and the no-argument method can be used if there is no need for a log
-   * message. For example:
-   * <pre>{@code
-   * logger.at(INFO).withCause(error).log();
-   * }</pre>
-   * <p>
-   * However as it is good practice to give all log statements a meaningful log message, use of this
-   * method should be rare.
-   */
-  void log();
-
-  /**
    * Logs a formatted representation of values in the given array, using the specified message
    * template.
    * <p>
@@ -301,6 +288,19 @@ public interface LoggingApi<API extends LoggingApi<API>> {
    * @param varargs the non-null array of arguments to be formatted.
    */
   void logVarargs(String message, Object[] varargs);
+
+  /**
+   * Terminal log statement when a message is not required. A {@code log} method must terminate all
+   * fluent logging chains and the no-argument method can be used if there is no need for a log
+   * message. For example:
+   * <pre>{@code
+   * logger.at(INFO).withCause(error).log();
+   * }</pre>
+   * <p>
+   * However as it is good practice to give all log statements a meaningful log message, use of this
+   * method should be rare.
+   */
+  void log();
 
   /**
    * Logs the given literal string without without interpreting any argument placeholders.
@@ -331,94 +331,94 @@ public interface LoggingApi<API extends LoggingApi<API>> {
    *
    * @param msg the message template string containing a single argument placeholder.
    */
-  void log(String msg, @Nullable Object p1);
+  void log(String msg, @NullableDecl Object p1);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, @Nullable Object p2);
+  void log(String msg, @NullableDecl Object p1, @NullableDecl Object p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, @Nullable Object p2, @Nullable Object p3);
-  /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(
-      String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4);
+  void log(String msg, @NullableDecl Object p1, @NullableDecl Object p2, @NullableDecl Object p3);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
   void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5);
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
   void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6);
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
   void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7);
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
   void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7,
-      @Nullable Object p8);
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
   void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7,
-      @Nullable Object p8,
-      @Nullable Object p9);
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7,
+      @NullableDecl Object p8);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
   void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7,
-      @Nullable Object p8,
-      @Nullable Object p9,
-      @Nullable Object p10);
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7,
+      @NullableDecl Object p8,
+      @NullableDecl Object p9);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
   void log(
       String msg,
-      @Nullable Object p1,
-      @Nullable Object p2,
-      @Nullable Object p3,
-      @Nullable Object p4,
-      @Nullable Object p5,
-      @Nullable Object p6,
-      @Nullable Object p7,
-      @Nullable Object p8,
-      @Nullable Object p9,
-      @Nullable Object p10,
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7,
+      @NullableDecl Object p8,
+      @NullableDecl Object p9,
+      @NullableDecl Object p10);
+  /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
+  void log(
+      String msg,
+      @NullableDecl Object p1,
+      @NullableDecl Object p2,
+      @NullableDecl Object p3,
+      @NullableDecl Object p4,
+      @NullableDecl Object p5,
+      @NullableDecl Object p6,
+      @NullableDecl Object p7,
+      @NullableDecl Object p8,
+      @NullableDecl Object p9,
+      @NullableDecl Object p10,
       Object... rest);
 
   // ---- Overloads for a single argument (to avoid auto-boxing and vararg array creation). ----
@@ -444,38 +444,38 @@ public interface LoggingApi<API extends LoggingApi<API>> {
    */
 
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, boolean p2);
+  void log(String msg, @NullableDecl Object p1, boolean p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, char p2);
+  void log(String msg, @NullableDecl Object p1, char p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, byte p2);
+  void log(String msg, @NullableDecl Object p1, byte p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, short p2);
+  void log(String msg, @NullableDecl Object p1, short p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, int p2);
+  void log(String msg, @NullableDecl Object p1, int p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, long p2);
+  void log(String msg, @NullableDecl Object p1, long p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, float p2);
+  void log(String msg, @NullableDecl Object p1, float p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, @Nullable Object p1, double p2);
+  void log(String msg, @NullableDecl Object p1, double p2);
 
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, boolean p1, @Nullable Object p2);
+  void log(String msg, boolean p1, @NullableDecl Object p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, char p1, @Nullable Object p2);
+  void log(String msg, char p1, @NullableDecl Object p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, byte p1, @Nullable Object p2);
+  void log(String msg, byte p1, @NullableDecl Object p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, short p1, @Nullable Object p2);
+  void log(String msg, short p1, @NullableDecl Object p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, int p1, @Nullable Object p2);
+  void log(String msg, int p1, @NullableDecl Object p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, long p1, @Nullable Object p2);
+  void log(String msg, long p1, @NullableDecl Object p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, float p1, @Nullable Object p2);
+  void log(String msg, float p1, @NullableDecl Object p2);
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
-  void log(String msg, double p1, @Nullable Object p2);
+  void log(String msg, double p1, @NullableDecl Object p2);
 
   /** Logs a message with formatted arguments (see {@link #log(String, Object)} for details). */
   void log(String msg, boolean p1, boolean p2);
@@ -636,7 +636,7 @@ public interface LoggingApi<API extends LoggingApi<API>> {
         String internalClassName,
         String methodName,
         int encodedLineNumber,
-        @Nullable String sourceFileName) {
+        @NullableDecl String sourceFileName) {
       return noOp();
     }
 
@@ -646,14 +646,14 @@ public interface LoggingApi<API extends LoggingApi<API>> {
     }
 
     @Override
-    public final <T> API with(MetadataKey<T> key, @Nullable T value) {
+    public final <T> API with(MetadataKey<T> key, @NullableDecl T value) {
       // Identical to the check in LogContext for consistency.
       checkNotNull(key, "metadata key");
       return noOp();
     }
 
     @Override
-    public final API withCause(@Nullable Throwable cause) {
+    public final API withCause(@NullableDecl Throwable cause) {
       return noOp();
     }
 
@@ -676,114 +676,114 @@ public interface LoggingApi<API extends LoggingApi<API>> {
     }
 
     @Override
+    public final void logVarargs(String msg, Object[] params) {}
+
+    @Override
     public final void log() {}
 
     @Override
     public final void log(String msg) {}
 
     @Override
-    public final void logVarargs(String msg, Object[] params) {}
+    public final void log(String msg, @NullableDecl Object p1) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1) {}
-
-    @Override
-    public final void log(String msg, @Nullable Object p1, @Nullable Object p2) {}
+    public final void log(String msg, @NullableDecl Object p1, @NullableDecl Object p2) {}
 
     @Override
     public final void log(
-        String msg, @Nullable Object p1, @Nullable Object p2, @Nullable Object p3) {}
+        String msg, @NullableDecl Object p1, @NullableDecl Object p2, @NullableDecl Object p3) {}
 
     @Override
     public final void log(
         String msg,
-        @Nullable Object p1,
-        @Nullable Object p2,
-        @Nullable Object p3,
-        @Nullable Object p4) {}
+        @NullableDecl Object p1,
+        @NullableDecl Object p2,
+        @NullableDecl Object p3,
+        @NullableDecl Object p4) {}
 
     @Override
     public final void log(
         String msg,
-        @Nullable Object p1,
-        @Nullable Object p2,
-        @Nullable Object p3,
-        @Nullable Object p4,
-        @Nullable Object p5) {}
+        @NullableDecl Object p1,
+        @NullableDecl Object p2,
+        @NullableDecl Object p3,
+        @NullableDecl Object p4,
+        @NullableDecl Object p5) {}
 
     @Override
     public final void log(
         String msg,
-        @Nullable Object p1,
-        @Nullable Object p2,
-        @Nullable Object p3,
-        @Nullable Object p4,
-        @Nullable Object p5,
-        @Nullable Object p6) {}
+        @NullableDecl Object p1,
+        @NullableDecl Object p2,
+        @NullableDecl Object p3,
+        @NullableDecl Object p4,
+        @NullableDecl Object p5,
+        @NullableDecl Object p6) {}
 
     @Override
     public final void log(
         String msg,
-        @Nullable Object p1,
-        @Nullable Object p2,
-        @Nullable Object p3,
-        @Nullable Object p4,
-        @Nullable Object p5,
-        @Nullable Object p6,
-        @Nullable Object p7) {}
+        @NullableDecl Object p1,
+        @NullableDecl Object p2,
+        @NullableDecl Object p3,
+        @NullableDecl Object p4,
+        @NullableDecl Object p5,
+        @NullableDecl Object p6,
+        @NullableDecl Object p7) {}
 
     @Override
     public final void log(
         String msg,
-        @Nullable Object p1,
-        @Nullable Object p2,
-        @Nullable Object p3,
-        @Nullable Object p4,
-        @Nullable Object p5,
-        @Nullable Object p6,
-        @Nullable Object p7,
-        @Nullable Object p8) {}
+        @NullableDecl Object p1,
+        @NullableDecl Object p2,
+        @NullableDecl Object p3,
+        @NullableDecl Object p4,
+        @NullableDecl Object p5,
+        @NullableDecl Object p6,
+        @NullableDecl Object p7,
+        @NullableDecl Object p8) {}
 
     @Override
     public final void log(
         String msg,
-        @Nullable Object p1,
-        @Nullable Object p2,
-        @Nullable Object p3,
-        @Nullable Object p4,
-        @Nullable Object p5,
-        @Nullable Object p6,
-        @Nullable Object p7,
-        @Nullable Object p8,
-        @Nullable Object p9) {}
+        @NullableDecl Object p1,
+        @NullableDecl Object p2,
+        @NullableDecl Object p3,
+        @NullableDecl Object p4,
+        @NullableDecl Object p5,
+        @NullableDecl Object p6,
+        @NullableDecl Object p7,
+        @NullableDecl Object p8,
+        @NullableDecl Object p9) {}
 
     @Override
     public final void log(
         String msg,
-        @Nullable Object p1,
-        @Nullable Object p2,
-        @Nullable Object p3,
-        @Nullable Object p4,
-        @Nullable Object p5,
-        @Nullable Object p6,
-        @Nullable Object p7,
-        @Nullable Object p8,
-        @Nullable Object p9,
-        @Nullable Object p10) {}
+        @NullableDecl Object p1,
+        @NullableDecl Object p2,
+        @NullableDecl Object p3,
+        @NullableDecl Object p4,
+        @NullableDecl Object p5,
+        @NullableDecl Object p6,
+        @NullableDecl Object p7,
+        @NullableDecl Object p8,
+        @NullableDecl Object p9,
+        @NullableDecl Object p10) {}
 
     @Override
     public final void log(
         String msg,
-        @Nullable Object p1,
-        @Nullable Object p2,
-        @Nullable Object p3,
-        @Nullable Object p4,
-        @Nullable Object p5,
-        @Nullable Object p6,
-        @Nullable Object p7,
-        @Nullable Object p8,
-        @Nullable Object p9,
-        @Nullable Object p10,
+        @NullableDecl Object p1,
+        @NullableDecl Object p2,
+        @NullableDecl Object p3,
+        @NullableDecl Object p4,
+        @NullableDecl Object p5,
+        @NullableDecl Object p6,
+        @NullableDecl Object p7,
+        @NullableDecl Object p8,
+        @NullableDecl Object p9,
+        @NullableDecl Object p10,
         Object... rest) {}
 
     @Override
@@ -802,52 +802,52 @@ public interface LoggingApi<API extends LoggingApi<API>> {
     public final void log(String msg, long p1) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1, boolean p2) {}
+    public final void log(String msg, @NullableDecl Object p1, boolean p2) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1, char p2) {}
+    public final void log(String msg, @NullableDecl Object p1, char p2) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1, byte p2) {}
+    public final void log(String msg, @NullableDecl Object p1, byte p2) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1, short p2) {}
+    public final void log(String msg, @NullableDecl Object p1, short p2) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1, int p2) {}
+    public final void log(String msg, @NullableDecl Object p1, int p2) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1, long p2) {}
+    public final void log(String msg, @NullableDecl Object p1, long p2) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1, float p2) {}
+    public final void log(String msg, @NullableDecl Object p1, float p2) {}
 
     @Override
-    public final void log(String msg, @Nullable Object p1, double p2) {}
+    public final void log(String msg, @NullableDecl Object p1, double p2) {}
 
     @Override
-    public final void log(String msg, boolean p1, @Nullable Object p2) {}
+    public final void log(String msg, boolean p1, @NullableDecl Object p2) {}
 
     @Override
-    public final void log(String msg, char p1, @Nullable Object p2) {}
+    public final void log(String msg, char p1, @NullableDecl Object p2) {}
 
     @Override
-    public final void log(String msg, byte p1, @Nullable Object p2) {}
+    public final void log(String msg, byte p1, @NullableDecl Object p2) {}
 
     @Override
-    public final void log(String msg, short p1, @Nullable Object p2) {}
+    public final void log(String msg, short p1, @NullableDecl Object p2) {}
 
     @Override
-    public final void log(String msg, int p1, @Nullable Object p2) {}
+    public final void log(String msg, int p1, @NullableDecl Object p2) {}
 
     @Override
-    public final void log(String msg, long p1, @Nullable Object p2) {}
+    public final void log(String msg, long p1, @NullableDecl Object p2) {}
 
     @Override
-    public final void log(String msg, float p1, @Nullable Object p2) {}
+    public final void log(String msg, float p1, @NullableDecl Object p2) {}
 
     @Override
-    public final void log(String msg, double p1, @Nullable Object p2) {}
+    public final void log(String msg, double p1, @NullableDecl Object p2) {}
 
     @Override
     public final void log(String msg, boolean p1, boolean p2) {}

--- a/api/src/main/java/com/google/common/flogger/backend/FormatChar.java
+++ b/api/src/main/java/com/google/common/flogger/backend/FormatChar.java
@@ -56,42 +56,46 @@ public enum FormatChar {
    * <p>
    * This is a numeric format.
    */
-  DECIMAL('d', FormatType.INTEGRAL, "-0+ ,", false  /* lower-case only */),
+  DECIMAL('d', FormatType.INTEGRAL, "-0+ ,(", false  /* lower-case only */),
 
   /**
    * Formats the argument as an unsigned octal integer.
    * <p>
    * This is a numeric format.
+   * <p>
+   * '(' is only supported for {@link java.math.BigInteger} or {@link java.math.BigDecimal}
    */
-  OCTAL('o', FormatType.INTEGRAL, "-#0", false  /* lower-case only */),
+  OCTAL('o', FormatType.INTEGRAL, "-#0(", false  /* lower-case only */),
 
   /**
    * Formats the argument as an unsigned hexadecimal integer.
    * <p>
    * This is a numeric format with an upper-case variant.
+   * <p>
+   * '(' is only supported for {@link java.math.BigInteger} or {@link java.math.BigDecimal}
    */
-  HEX('x', FormatType.INTEGRAL, "-#0", true /* upper-case variant */),
+  HEX('x', FormatType.INTEGRAL, "-#0(", true /* upper-case variant */),
 
   /**
    * Formats the argument as a signed decimal floating value.
    * <p>
    * This is a numeric format.
    */
-  FLOAT('f', FormatType.FLOAT, "-#0+ ,", false  /* lower-case only */),
+  FLOAT('f', FormatType.FLOAT, "-#0+ ,(", false  /* lower-case only */),
 
   /**
    * Formats the argument using computerized scientific notation.
    * <p>
    * This is a numeric format with an upper-case variant.
    */
-  EXPONENT('e', FormatType.FLOAT, "-#0+ ", true /* upper-case variant */),
+  EXPONENT('e', FormatType.FLOAT, "-#0+ (", true /* upper-case variant */),
 
   /**
    * Formats the argument using general scientific notation.
    * <p>
    * This is a numeric format with an upper-case variant.
    */
-  GENERAL('g', FormatType.FLOAT, "-0+ ,", true /* upper-case variant */),
+  GENERAL('g', FormatType.FLOAT, "-0+ ,(", true /* upper-case variant */),
 
   /**
    * Formats the argument using hexadecimal exponential form. This formatting option is primarily

--- a/api/src/main/java/com/google/common/flogger/backend/FormatOptions.java
+++ b/api/src/main/java/com/google/common/flogger/backend/FormatOptions.java
@@ -17,7 +17,7 @@
 package com.google.common.flogger.backend;
 
 import com.google.common.flogger.parser.ParseException;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A structured representation of formatting options compatible with printf style formatting.
@@ -490,7 +490,7 @@ public final class FormatOptions {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(@NullableDecl Object o) {
     // Various functions ensure that the same instance gets re-used, so it seems likely that it's
     // worth optimizing for it here.
     if (o == this) {

--- a/api/src/main/java/com/google/common/flogger/backend/KeyValueFormatter.java
+++ b/api/src/main/java/com/google/common/flogger/backend/KeyValueFormatter.java
@@ -18,7 +18,7 @@ package com.google.common.flogger.backend;
 
 import java.util.HashSet;
 import java.util.Set;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Formats key/value pairs as a human readable string on the end of log statements. The format is:
@@ -88,7 +88,7 @@ class KeyValueFormatter implements KeyValueHandler {
   }
 
   @Override
-  public KeyValueFormatter handle(String label, @Nullable Object value) {
+  public KeyValueFormatter handle(String label, @NullableDecl Object value) {
     if (haveSeenValues) {
       out.append(' ');
     } else {

--- a/api/src/main/java/com/google/common/flogger/backend/KeyValueHandler.java
+++ b/api/src/main/java/com/google/common/flogger/backend/KeyValueHandler.java
@@ -16,7 +16,7 @@
 
 package com.google.common.flogger.backend;
 
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Callback interface to handle additional contextual key/value pairs with log statements. Used
@@ -27,5 +27,5 @@ public interface KeyValueHandler {
    * Handle a single key value pair of contextual metadata for a log statement. Note that it is
    * permitted for the value to be null if a tag was added by name only.
    */
-  KeyValueHandler handle(String key, @Nullable Object value);
+  KeyValueHandler handle(String key, @NullableDecl Object value);
 }

--- a/api/src/main/java/com/google/common/flogger/backend/LoggingException.java
+++ b/api/src/main/java/com/google/common/flogger/backend/LoggingException.java
@@ -16,7 +16,7 @@
 
 package com.google.common.flogger.backend;
 
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Exception thrown when a log statement cannot be emitted correctly. This exception should only be
@@ -30,11 +30,11 @@ import javax.annotation.Nullable;
  */
 public class LoggingException extends RuntimeException {
 
-  public LoggingException(@Nullable String message) {
+  public LoggingException(@NullableDecl String message) {
     super(message);
   }
 
-  public LoggingException(@Nullable String message, @Nullable Throwable cause) {
+  public LoggingException(@NullableDecl String message, @NullableDecl Throwable cause) {
     super(message, cause);
   }
 }

--- a/api/src/main/java/com/google/common/flogger/backend/Metadata.java
+++ b/api/src/main/java/com/google/common/flogger/backend/Metadata.java
@@ -17,7 +17,7 @@
 package com.google.common.flogger.backend;
 
 import com.google.common.flogger.MetadataKey;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Optional debug information which can be attached to a log statement. Metadata is represented as
@@ -105,7 +105,7 @@ public abstract class Metadata {
     }
 
     @Override
-    @Nullable
+    @NullableDecl
     public <T> T findValue(MetadataKey<T> key) {
       return null;
     }
@@ -133,6 +133,6 @@ public abstract class Metadata {
    *
    * @throws NullPointerException if {@code key} is {@code null}.
    */
-  @Nullable
+  @NullableDecl
   public abstract <T> T findValue(MetadataKey<T> key);
 }

--- a/api/src/main/java/com/google/common/flogger/backend/SimpleMessageFormatter.java
+++ b/api/src/main/java/com/google/common/flogger/backend/SimpleMessageFormatter.java
@@ -39,7 +39,7 @@ import java.util.FormattableFlags;
 import java.util.Formatter;
 import java.util.Locale;
 import java.util.logging.Level;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Helper class for formatting LogData as text. This class is useful for any logging backend which
@@ -61,7 +61,7 @@ public final class SimpleMessageFormatter extends MessageBuilder<StringBuilder>
      * Handles a single formatted log statement with the given level, message and "cause". This is
      * called back exactly once, from the same thread, for every call made to {@link #format}.
      */
-    void handleFormattedLogMessage(Level level, String message, @Nullable Throwable thrown);
+    void handleFormattedLogMessage(Level level, String message, @NullableDecl Throwable thrown);
   }
 
   /**

--- a/api/src/main/java/com/google/common/flogger/backend/SimpleMessageFormatter.java
+++ b/api/src/main/java/com/google/common/flogger/backend/SimpleMessageFormatter.java
@@ -344,7 +344,7 @@ public final class SimpleMessageFormatter extends MessageBuilder<StringBuilder>
       default:
         // Fall through.
     }
-    // Default handle for rare cases that need non-tivial formatting.
+    // Default handle for rare cases that need non-trivial formatting.
     String formatString = format.getDefaultFormatString();
     if (!options.isDefault()) {
       char chr = format.getChar();

--- a/api/src/main/java/com/google/common/flogger/backend/Tags.java
+++ b/api/src/main/java/com/google/common/flogger/backend/Tags.java
@@ -28,7 +28,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Immutable tags which can be attached to log statements via platform specific injection
@@ -340,7 +340,7 @@ public final class Tags {
   }
 
   @Override
-  public boolean equals(@Nullable Object obj) {
+  public boolean equals(@NullableDecl Object obj) {
     return (obj instanceof Tags) && ((Tags) obj).map.equals(map);
   }
 

--- a/api/src/main/java/com/google/common/flogger/backend/system/DefaultPlatform.java
+++ b/api/src/main/java/com/google/common/flogger/backend/system/DefaultPlatform.java
@@ -21,7 +21,7 @@ import com.google.common.flogger.backend.Platform;
 import com.google.common.flogger.backend.Tags;
 import com.google.common.flogger.util.Checks;
 import java.util.logging.Level;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * The default fluent logger platform for a server-side Java environment. The default platform
@@ -119,7 +119,7 @@ public class DefaultPlatform extends Platform {
    * @return the return value of the specified static no-argument method, or null if the method
    *     cannot be called or the returned value is of the wrong type.
    */
-  @Nullable
+  @NullableDecl
   private static <T> T resolveAttribute(String attributeName, Class<T> type) {
     String getter = readProperty(attributeName);
     if (getter == null) {

--- a/api/src/main/java/com/google/common/flogger/backend/system/SimpleLogRecord.java
+++ b/api/src/main/java/com/google/common/flogger/backend/system/SimpleLogRecord.java
@@ -21,7 +21,7 @@ import com.google.common.flogger.backend.SimpleMessageFormatter;
 import com.google.common.flogger.backend.SimpleMessageFormatter.SimpleLogHandler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * An eagerly evaluating {@link LogRecord} which is created by the Fluent Logger frontend and can be
@@ -54,7 +54,7 @@ public final class SimpleLogRecord extends AbstractLogRecord implements SimpleLo
   }
 
   @Override
-  public void handleFormattedLogMessage(Level level, String message, @Nullable Throwable thrown) {
+  public void handleFormattedLogMessage(Level level, String message, @NullableDecl Throwable thrown) {
     // Ignore the log level as our parent class already set it (that's used in Android).
     setMessage(message);
     setThrown(thrown);

--- a/api/src/main/java/com/google/common/flogger/package-info.java
+++ b/api/src/main/java/com/google/common/flogger/package-info.java
@@ -21,8 +21,6 @@
  * <a href="https://google.github.io/flogger">Flogger library</a>.
  */
 @CheckReturnValue
-@ParametersAreNonnullByDefault
 package com.google.common.flogger;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/src/main/java/com/google/common/flogger/parameter/package-info.java
+++ b/api/src/main/java/com/google/common/flogger/parameter/package-info.java
@@ -21,8 +21,6 @@
  * <a href="https://google.github.io/flogger">Flogger library</a>.
  */
 @CheckReturnValue
-@ParametersAreNonnullByDefault
 package com.google.common.flogger.parameter;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/src/main/java/com/google/common/flogger/parser/package-info.java
+++ b/api/src/main/java/com/google/common/flogger/parser/package-info.java
@@ -21,8 +21,6 @@
  * <a href="https://google.github.io/flogger">Flogger library</a>.
  */
 @CheckReturnValue
-@ParametersAreNonnullByDefault
 package com.google.common.flogger.parser;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/api/src/main/java/com/google/common/flogger/util/CallerFinder.java
+++ b/api/src/main/java/com/google/common/flogger/util/CallerFinder.java
@@ -19,7 +19,7 @@ package com.google.common.flogger.util;
 import static com.google.common.flogger.util.Checks.checkNotNull;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** A helper class for determining callers of a specified class currently on the stack. */
 @CheckReturnValue
@@ -40,7 +40,7 @@ public final class CallerFinder {
    * @return the stack trace element representing the immediate caller of the specified class, or
    *     null if no caller was found (due to incorrect target, wrong skip count or use of JNI).
    */
-  @Nullable
+  @NullableDecl
   public static StackTraceElement findCallerOf(Class<?> target, Throwable throwable, int skip) {
     checkNotNull(target, "target");
     checkNotNull(throwable, "throwable");
@@ -85,7 +85,6 @@ public final class CallerFinder {
    *     the empty array if no caller was found (due to incorrect target, wrong skip count or use
    *     of JNI).
    */
-  @Nullable
   public static StackTraceElement[] getStackForCallerOf(
       Class<?> target, Throwable throwable, int maxDepth) {
     checkNotNull(target, "target");

--- a/api/src/main/java/com/google/common/flogger/util/FastStackGetter.java
+++ b/api/src/main/java/com/google/common/flogger/util/FastStackGetter.java
@@ -19,7 +19,7 @@ package com.google.common.flogger.util;
 import com.google.errorprone.annotations.CheckReturnValue;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A helper class to abstract the complexities of dynamically invoking the
@@ -31,7 +31,7 @@ final class FastStackGetter {
    * @return a new {@code FastStackGetter} if the {@code getStackTraceElement()} method of
    * {@code JavaLangAccess} is supported on this platform, or {@code null} otherwise.
    */
-  @Nullable
+  @NullableDecl
   public static FastStackGetter createIfSupported() {
     try {
       Object javaLangAccess =

--- a/api/src/main/java/com/google/common/flogger/util/StackBasedLogSite.java
+++ b/api/src/main/java/com/google/common/flogger/util/StackBasedLogSite.java
@@ -20,7 +20,7 @@ import static com.google.common.flogger.util.Checks.checkNotNull;
 
 import com.google.common.flogger.LogSite;
 import com.google.errorprone.annotations.CheckReturnValue;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A stack based log site which uses information from a given {@code StackTraceElement}.
@@ -64,7 +64,7 @@ public final class StackBasedLogSite extends LogSite {
   }
 
   @Override
-  public boolean equals(@Nullable Object obj) {
+  public boolean equals(@NullableDecl Object obj) {
     return (obj instanceof StackBasedLogSite)
         && stackElement.equals(((StackBasedLogSite) obj).stackElement);
   }

--- a/api/src/test/java/com/google/common/flogger/backend/SimpleMessageFormatterTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/SimpleMessageFormatterTest.java
@@ -35,7 +35,7 @@ import java.util.FormatFlagsConversionMismatchException;
 import java.util.Formattable;
 import java.util.Formatter;
 import java.util.logging.Level;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -279,7 +279,7 @@ public class SimpleMessageFormatterTest {
         private String captured = null;
 
         @Override
-        public void handleFormattedLogMessage(Level lvl, String msg, @Nullable Throwable e) {
+        public void handleFormattedLogMessage(Level lvl, String msg, @NullableDecl Throwable e) {
           captured = msg;
         }
 

--- a/api/src/test/java/com/google/common/flogger/testing/FakeMetadata.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FakeMetadata.java
@@ -22,7 +22,7 @@ import com.google.common.flogger.MetadataKey;
 import com.google.common.flogger.backend.Metadata;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 public final class FakeMetadata extends Metadata {
 
@@ -54,7 +54,7 @@ public final class FakeMetadata extends Metadata {
   }
 
   @Override
-  @Nullable
+  @NullableDecl
   public <T> T findValue(MetadataKey<T> key) {
     for (KeyValuePair<?> e : entries) {
       if (e.key.equals(key)) {

--- a/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatOptionsSubject.java
@@ -23,7 +23,7 @@ import com.google.common.flogger.backend.FormatChar;
 import com.google.common.flogger.backend.FormatOptions;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A <a href="https://github.com/google/truth">Truth</a> subject for {@link FormatOptions}.
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
  */
 public final class FormatOptionsSubject extends Subject {
 
-  public static FormatOptionsSubject assertThat(@Nullable FormatOptions formatOptions) {
+  public static FormatOptionsSubject assertThat(@NullableDecl FormatOptions formatOptions) {
     return assertAbout(FormatOptionsSubject.FORMAT_OPTIONS_FACTORY).that(formatOptions);
   }
 
@@ -41,7 +41,7 @@ public final class FormatOptionsSubject extends Subject {
 
   private final FormatOptions actual;
 
-  private FormatOptionsSubject(FailureMetadata failureMetadata, @Nullable FormatOptions subject) {
+  private FormatOptionsSubject(FailureMetadata failureMetadata, @NullableDecl FormatOptions subject) {
     super(failureMetadata, subject);
     this.actual = subject;
   }

--- a/api/src/test/java/com/google/common/flogger/testing/FormatTypeSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/FormatTypeSubject.java
@@ -22,7 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import com.google.common.flogger.backend.FormatType;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A <a href="https://github.com/google/truth">Truth</a> subject for {@link FormatType}.
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  */
 public final class FormatTypeSubject extends Subject {
 
-  public static FormatTypeSubject assertThat(@Nullable FormatType formatType) {
+  public static FormatTypeSubject assertThat(@NullableDecl FormatType formatType) {
     return assertAbout(FormatTypeSubject.FORMAT_TYPE_SUBJECT_FACTORY).that(formatType);
   }
 
@@ -40,7 +40,7 @@ public final class FormatTypeSubject extends Subject {
 
   private final FormatType actual;
 
-  private FormatTypeSubject(FailureMetadata failureMetadata, @Nullable FormatType subject) {
+  private FormatTypeSubject(FailureMetadata failureMetadata, @NullableDecl FormatType subject) {
     super(failureMetadata, subject);
     this.actual = subject;
   }

--- a/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/LogDataSubject.java
@@ -26,7 +26,7 @@ import com.google.common.truth.Subject;
 import com.google.errorprone.annotations.CheckReturnValue;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** A <a href="https://github.com/google/truth">Truth</a> subject for {@link LogData}. */
 @CheckReturnValue
@@ -38,13 +38,13 @@ public final class LogDataSubject extends Subject {
     return LOG_DATA_SUBJECT_FACTORY;
   }
 
-  public static LogDataSubject assertThat(@Nullable LogData logData) {
+  public static LogDataSubject assertThat(@NullableDecl LogData logData) {
     return assertAbout(logData()).that(logData);
   }
 
   private final LogData actual;
 
-  private LogDataSubject(FailureMetadata failureMetadata, @Nullable LogData subject) {
+  private LogDataSubject(FailureMetadata failureMetadata, @NullableDecl LogData subject) {
     super(failureMetadata, subject);
     this.actual = subject;
   }

--- a/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
+++ b/api/src/test/java/com/google/common/flogger/testing/MetadataSubject.java
@@ -27,7 +27,7 @@ import com.google.common.truth.IterableSubject;
 import com.google.common.truth.Subject;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** A <a href="https://github.com/google/truth">Truth</a> subject for {@link Metadata}. */
 public final class MetadataSubject extends Subject {
@@ -38,13 +38,13 @@ public final class MetadataSubject extends Subject {
     return METADATA_SUBJECT_FACTORY;
   }
 
-  public static MetadataSubject assertThat(@Nullable Metadata metadata) {
+  public static MetadataSubject assertThat(@NullableDecl Metadata metadata) {
     return assertAbout(metadata()).that(metadata);
   }
 
   private final Metadata actual;
 
-  private MetadataSubject(FailureMetadata failureMetadata, @Nullable Metadata subject) {
+  private MetadataSubject(FailureMetadata failureMetadata, @NullableDecl Metadata subject) {
     super(failureMetadata, subject);
     this.actual = subject;
   }

--- a/google/BUILD
+++ b/google/BUILD
@@ -21,7 +21,6 @@ java_library(
         "@google_bazel_common//third_party/java/error_prone:annotations",
         # TODO(dbeaumont): Split this so truly public things can be exported
         # without needing implementation to be visible to the world.
-        "@google_bazel_common//third_party/java/jsr305_annotations",
         "//api",
         "//api:checks",
     ],

--- a/log4j/BUILD
+++ b/log4j/BUILD
@@ -16,7 +16,6 @@ java_library(
     deps = [
         "//api",
         "//api:system_backend",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
         "@google_bazel_common//third_party/java/log4j",
     ],
 )
@@ -50,8 +49,8 @@ gen_java_tests(
         ":log4j_backend",
         "//api",
         "//api:testing",
+        "@google_bazel_common//third_party/java/checker_framework_annotations",
         "@google_bazel_common//third_party/java/guava",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
         "@google_bazel_common//third_party/java/junit",
         "@google_bazel_common//third_party/java/log4j",
         "@google_bazel_common//third_party/java/truth",

--- a/log4j/src/test/java/com/google/common/flogger/backend/log4j/LogDataFormatterTest.java
+++ b/log4j/src/test/java/com/google/common/flogger/backend/log4j/LogDataFormatterTest.java
@@ -24,7 +24,7 @@ import com.google.common.flogger.backend.LogData;
 import com.google.common.flogger.backend.SimpleMessageFormatter.SimpleLogHandler;
 import com.google.common.flogger.testing.FakeLogData;
 import java.util.logging.Level;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -80,7 +80,7 @@ public class LogDataFormatterTest {
       private String captured = null;
 
       @Override
-      public void handleFormattedLogMessage(Level lvl, String msg, @Nullable Throwable e) {
+      public void handleFormattedLogMessage(Level lvl, String msg, @NullableDecl Throwable e) {
         captured = msg;
       }
 

--- a/log4j2/BUILD
+++ b/log4j2/BUILD
@@ -49,7 +49,6 @@ gen_java_tests(
         "//api",
         "//api:testing",
         "@google_bazel_common//third_party/java/guava",
-        "@google_bazel_common//third_party/java/jsr305_annotations",
         "@google_bazel_common//third_party/java/junit",
         "@google_bazel_common//third_party/java/log4j2",
         "@google_bazel_common//third_party/java/truth",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add support for '(' flag in Flogger for negative numbers.

RELNOTES=Add support for '(' flag in Flogger for negative numbers

c718a40708d44b1c273d347ea086215cad13496f

-------

<p> Roll forward after fixing the rollback issue.

I removed the annotation, because it was unnecessary - the method always returns a non-null value.

*** Original change description ***

Use Checker framework @NullableDecl instead of javax @Nullable

This leaves @ParametersAreNonnullByDefault the only jsr305 annotation left.
Ran build_cleaner on affected build files.

***

95e7820db68e4ba25906ad6640645da47dec7814

-------

<p> A presubmit check to prohibit JSR305 in open-source code.

RELNOTES=N/A

5c75b1aac80e35ece2b8b8395cdfd3045864d998