### PR TITLE
MOE Sync 2020-01-28

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,8 +16,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "google_bazel_common",
-    strip_prefix = "bazel-common-365bdc5779d2fa86eca9e7ed99f1198e431d049d",
-    urls = ["https://github.com/google/bazel-common/archive/365bdc5779d2fa86eca9e7ed99f1198e431d049d.zip"],
+    strip_prefix = "bazel-common-76d25d1921c2534c7654aebb2e7cf687cfb469aa",
+    urls = ["https://github.com/google/bazel-common/archive/76d25d1921c2534c7654aebb2e7cf687cfb469aa.zip"],
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")

--- a/api/src/main/java/com/google/common/flogger/LogContext.java
+++ b/api/src/main/java/com/google/common/flogger/LogContext.java
@@ -1246,7 +1246,7 @@ public abstract class LogContext<
   }
 
   @Override
-  public final void logVarargs(String message, Object[] params) {
+  public final void logVarargs(String message, @NullableDecl Object[] params) {
     if (shouldLog()) {
       // Copy the varargs array (because we didn't create it and this is quite a rare case).
       logImpl(message, Arrays.copyOf(params, params.length));

--- a/api/src/main/java/com/google/common/flogger/LoggingApi.java
+++ b/api/src/main/java/com/google/common/flogger/LoggingApi.java
@@ -287,7 +287,7 @@ public interface LoggingApi<API extends LoggingApi<API>> {
    * @param message the message template string containing a single argument placeholder.
    * @param varargs the non-null array of arguments to be formatted.
    */
-  void logVarargs(String message, Object[] varargs);
+  void logVarargs(String message, @NullableDecl Object[] varargs);
 
   /**
    * Terminal log statement when a message is not required. A {@code log} method must terminate all

--- a/api/src/test/java/com/google/common/flogger/LogContextTest.java
+++ b/api/src/test/java/com/google/common/flogger/LogContextTest.java
@@ -258,10 +258,10 @@ public class LogContextTest {
     FakeLoggerBackend backend = new FakeLoggerBackend();
     FluentLogger logger = new FluentLogger(backend);
 
-    Object[] args = new Object[] {"foo", "bar", "baz"};
+    Object[] args = new Object[] {"foo", null, "baz"};
     logger.atInfo().logVarargs("Any message ...", args);
 
-    backend.assertLastLogged().hasArguments("foo", "bar", "baz");
+    backend.assertLastLogged().hasArguments("foo", null, "baz");
     // Make sure we took a copy of the arguments rather than risk re-using them.
     assertThat(backend.getLoggedCount()).isEqualTo(1);
     assertThat(backend.getLogged(0).getArguments()).isNotSameInstanceAs(args);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Explicitly allow logVarargs to take an array containing null objects.

This is already supported for log() calls which take @NullableDect Object
params and then pass them into logImpl (see
http://third_party/java_src/flogger/api/src/main/java/com/google/common/flogger/LogContext.java?rcl=289240473&l=896).

This is so a @FormatMethod which uses "@Nullable Object... args" can pass the
args directly to logVarargs() without a static analysis test failing.

RELNOTES=Explicitly allow an array containing null objects in logVarargs().

5ab95a35f47f355e6cdec14f89eea939d4e869bf

-------

<p> Update google_bazel_common to newer version

This fixes building `//...`, which failed because
maven artifacts could no longer be fetched from
"http" URLs.

Fixes #128

4ee74ef59617699aa3a1940406a56b54d17f235f