### PR TITLE
MOE Sync 2020-02-04

### DIFF
--- a/api/src/test/java/com/google/common/flogger/parser/DefaultBraceStyleMessageParserTest.java
+++ b/api/src/test/java/com/google/common/flogger/parser/DefaultBraceStyleMessageParserTest.java
@@ -18,7 +18,7 @@ package com.google.common.flogger.parser;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/api/src/test/java/com/google/common/flogger/parser/DefaultPrintfMessageParserTest.java
+++ b/api/src/test/java/com/google/common/flogger/parser/DefaultPrintfMessageParserTest.java
@@ -18,7 +18,7 @@ package com.google.common.flogger.parser;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate static imports of org.mockito.Matchers to org.mockito.ArgumentMatchers

The former is deprecated and replaced by the latter in Mockito 2.

3f2ca5722e6d11914200449ab2ea25e074e7c180