### PR TITLE
Add support for creating a FluentLogger with a specific logger name

### DIFF
--- a/api/src/main/java/com/google/common/flogger/FluentLogger.java
+++ b/api/src/main/java/com/google/common/flogger/FluentLogger.java
@@ -71,6 +71,14 @@ public final class FluentLogger extends AbstractLogger<FluentLogger.Api> {
     return new FluentLogger(Platform.getBackend(loggingClass));
   }
 
+  /**
+   * Returns a new logger instance which parses log messages using printf format for the given
+   * log name using the system default logging backend.
+   */
+  public static FluentLogger withName(String name) {
+    return new FluentLogger(Platform.getBackend(name));
+  }
+
   // Visible for testing.
   FluentLogger(LoggerBackend backend) {
     super(backend);

--- a/api/src/test/java/com/google/common/flogger/FluentLoggerTest.java
+++ b/api/src/test/java/com/google/common/flogger/FluentLoggerTest.java
@@ -46,6 +46,12 @@ public class FluentLoggerTest {
   }
 
   @Test
+  public void testCreateWithName() {
+    FluentLogger logger = FluentLogger.withName("my_logger");
+    assertThat(logger.getBackend().getLoggerName()).isEqualTo("my_logger");
+  }
+
+  @Test
   public void testNoOp() {
     FakeLoggerBackend backend = new FakeLoggerBackend();
     FluentLogger logger = new FluentLogger(backend);


### PR DESCRIPTION
This is needed to allow migration from slf4j/log4j in projects where
loggers are created via LoggerFactory.getLogger(String) and the logger
name needs to be unchanged.

See [1] for more context.

[1] https://gerrit-review.googlesource.com/c/plugins/replication/+/183158
