### PR TITLE
MOE Sync 2020-03-26

### DIFF
--- a/api/src/main/java/com/google/common/flogger/LoggerConfig.java
+++ b/api/src/main/java/com/google/common/flogger/LoggerConfig.java
@@ -59,6 +59,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * </ul>
  */
 // TODO(dbeaumont): Move this to a new package so it's clear it's NOT part of the core Flogger API.
+@Deprecated // See https://github.com/google/flogger/issues/142.
 @CheckReturnValue
 public final class LoggerConfig {
   /**
@@ -89,7 +90,7 @@ public final class LoggerConfig {
     return getConfig(fluentLogger.getName());
   }
 
-/**
+  /**
    * Returns a configuration instance suitable for configuring the logger of the specified class.
    *
    * <p>This method obtains and wraps the underlying logger for the given class, retaining a strong


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Mark LoggerConfig as deprecated in open source. I'll remove it from open source in 2 weeks.

https://github.com/google/flogger/issues/142

RELNOTES=Mark LoggerConfig as deprecated in open source (https://github.com/google/flogger/issues/142).

f7567061aa4584d84000a8327ce34b2feac40c6c