### PR TITLE
MOE Sync 2020-03-30

### DIFF
--- a/api/src/main/java/com/google/common/flogger/LogSites.java
+++ b/api/src/main/java/com/google/common/flogger/LogSites.java
@@ -96,7 +96,7 @@ public final class LogSites {
    * }</pre>
    * <p>
    * Because this method adds an additional parameter and exposes a Flogger specific type to the
-   * calling code, you should consider using {@link #callerOf(Class<?>)} for simple logging
+   * calling code, you should consider using {@link #callerOf(Class)} for simple logging
    * utilities.
    * <p>
    * It is very important to note that this method can be very slow, since determining the log site


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix invalid Javadoc (all @link references use their erasure types)

8f783c592e86b769d3bbd3e61071d5dbe9086ff9