### PR TITLE
MOE Sync 2020-04-30

### DIFF
--- a/api/proguard.cfg
+++ b/api/proguard.cfg
@@ -1,3 +1,3 @@
 # Don't warn about the platforms not being found - they aren't available
 # everywhere, by design. Platforms are loaded dynamically at runtime.
--dontwarn com.google.common.flogger.backend.system.DefaultPlatform
+-dontwarn com.google.common.flogger.backend.system.DefaultPlatform*


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Changing flogger api proguard.cfg dontwarn to include inner classes

AndroidPlatform uses an inner class (new LogCallerFinder{...}), and that inner class uses dalvik.system.VMStack. This causes warnings when using proguard_frontend.

6c54cddbc68bc0d34f73f104ba795f876d22abb8