### PR TITLE
Excluding :log_sites target from pom_file

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -93,7 +93,6 @@ pom_file(
         ":context",
         ":lazy_args",
         ":log_site",
-        ":log_sites",
         ":platform_provider",
         ":reflection_utils",
         ":stack",


### PR DESCRIPTION
Fixes #152 .

@ronshapiro @cpovirk Do you think this `:log_sites` line in the `pom_file` section is doing anything other than inserting the invalid dependency element (#152 )?

```
suztomo@suztomo:~/flogger$ diff /usr/local/google/home/suztomo/.m2/repository/com/google/flogger/flogger/local-suztomo-patch1/flogger-local-suztomo-patch1.pom /usr/local/google/home/suztomo/.m2/repository/com/google/flogger/flogger/local-master/flogger-local-master.pom 
29c29
<   <version>local-suztomo-patch1</version>
---
>   <version>local-master</version>
57a58,62
> <dependency>
>   <groupId>com.google.flogger</groupId>
>   <artifactId>flogger</artifactId>
>   <version>${project.version}</version>
> </dependency>

suztomo@suztomo:~/flogger$ md5sum /usr/local/google/home/suztomo/.m2/repository/com/google/flogger/flogger/local-suztomo-patch1/flogger-local-suztomo-patch1.jar /usr/local/google/home/suztomo/.m2/repository/com/google/flogger/flogger/local-master/flogger-local-master.jar 
0f9cf2a9cecaf1060dbf6573985b5c24  /usr/local/google/home/suztomo/.m2/repository/com/google/flogger/flogger/local-suztomo-patch1/flogger-local-suztomo-patch1.jar
0f9cf2a9cecaf1060dbf6573985b5c24  /usr/local/google/home/suztomo/.m2/repository/com/google/flogger/flogger/local-master/flogger-local-master.jar
```