### PR TITLE
MOE Sync 2020-06-16

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -22,10 +22,12 @@ layout: base
     </div>
   </header>
 
-  {% include sidenav.html %}
+  <div class="c-article__container">
+    {% include sidenav.html %}
 
-  <div class="c-article__main">
-    {{ content }}
+    <div class="c-article__main">
+      {{ content }}
+    </div>
   </div>
 
   {% include codeselector.html %}

--- a/docs/_sass/components/_article.scss
+++ b/docs/_sass/components/_article.scss
@@ -22,6 +22,16 @@
 
 }
 
+.c-article__container {
+  display: block;
+}
+
+@media (min-width: 42rem) {
+  .c-article__container {
+    display: flex;
+  }
+}
+
 .c-article__main {
   max-width: 76rem; // 760px;
   margin-right: auto;

--- a/docs/_sass/components/_callouts.scss
+++ b/docs/_sass/components/_callouts.scss
@@ -22,10 +22,18 @@
   color: #0277bd;
   background-color: #e1f5fe;
   padding: 1rem 2rem;
+
+  a {
+    color: #024369
+  }
 }
 
 .c-callouts__warning {
   color: #a52714;
   background-color: #fbe9e7;
   padding: 1rem 2rem;
+
+  a {
+    color: #731c0d
+  }
 }

--- a/docs/_sass/components/_callouts.scss
+++ b/docs/_sass/components/_callouts.scss
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ==========================================================================
+   Callouts
+   ========================================================================== */
+
+.c-callouts__note {
+  color: #0277bd;
+  background-color: #e1f5fe;
+  padding: 1rem 2rem;
+}
+
+.c-callouts__warning {
+  color: #a52714;
+  background-color: #fbe9e7;
+  padding: 1rem 2rem;
+}

--- a/docs/_sass/components/_codeselector.scss
+++ b/docs/_sass/components/_codeselector.scss
@@ -23,8 +23,9 @@
   @include fs--body;
   outline: none;
   border: none;
-  padding-left: 10px;
-  padding-right: 10px;
+  padding-left: 1rem;
+  padding-bottom: .5rem;
+  padding-right: 1rem;
   display: inline-block;
 
   &:after {

--- a/docs/_sass/components/_sidenav.scss
+++ b/docs/_sass/components/_sidenav.scss
@@ -19,12 +19,8 @@
    ========================================================================== */
 
 .c-sidenav {
-  position: relative;
-  float:left;
-  left: 0;
   padding: 0 2.5rem 2.5rem;
   background: $t-theme;
-  z-index: 10;
   list-style-type: none;
 
   &.is-fixed {

--- a/docs/_sass/themes/_blue.scss
+++ b/docs/_sass/themes/_blue.scss
@@ -27,7 +27,7 @@
     background: $c__blue;
   }
 
-  .c-article__main a:not(.c-btn) {
+  .c-article__main :not(.c-callouts__note):not(.c-callouts__warning) > a:not(.c-btn) {
     color: $c__blue;
   }
 

--- a/docs/_sass/themes/_green.scss
+++ b/docs/_sass/themes/_green.scss
@@ -27,7 +27,7 @@
     background: $c__green;
   }
 
-  .c-article__main a:not(.c-btn) {
+  .c-article__main :not(.c-callouts__note):not(.c-callouts__warning) > a:not(.c-btn) {
     color: $c__green;
   }
 

--- a/docs/_sass/themes/_grey.scss
+++ b/docs/_sass/themes/_grey.scss
@@ -27,7 +27,7 @@
     background: $c__blue-grey;
   }
 
-  .c-article__main a:not(.c-btn) {
+  .c-article__main :not(.c-callouts__note):not(.c-callouts__warning) > a:not(.c-btn) {
     color: $c__blue-grey;
   }
 

--- a/docs/_sass/themes/_orange.scss
+++ b/docs/_sass/themes/_orange.scss
@@ -27,7 +27,7 @@
     background: $c__deep-orange;
   }
 
-  .c-article__main a:not(.c-btn) {
+  .c-article__main :not(.c-callouts__note):not(.c-callouts__warning) > a:not(.c-btn) {
     color: $c__deep-orange;
   }
 

--- a/docs/_sass/themes/_purple.scss
+++ b/docs/_sass/themes/_purple.scss
@@ -27,7 +27,7 @@
     background: $c__deep-purple;
   }
 
-  .c-article__main a:not(.c-btn) {
+  .c-article__main :not(.c-callouts__note):not(.c-callouts__warning) > a:not(.c-btn) {
     color: $c__deep-purple;
   }
 

--- a/docs/_sass/themes/_teal.scss
+++ b/docs/_sass/themes/_teal.scss
@@ -27,7 +27,7 @@
     background: $c__teal;
   }
 
-  .c-article__main a:not(.c-btn) {
+  .c-article__main :not(.c-callouts__note):not(.c-callouts__warning) > a:not(.c-btn) {
     color: $c__teal;
   }
 

--- a/docs/css/main.scss
+++ b/docs/css/main.scss
@@ -40,7 +40,8 @@
   'components/social',
   'components/buttons',
   'components/footer',
-  'components/codeselector';
+  'components/codeselector',
+  'components/callouts';
 
 // Themes
 @import


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Tweak at(Level) to be 35 bytecodes.

This puts it below at least one cutoff involved in inlining decisions:
https://stackoverflow.com/a/36585311/28465

2b6449e350acbf39482e6f84fb7aa24983e66dfb

-------

<p> Add styling for note and warning callout blocks.

270f809b22810fccc1b109807227894a70775d4b

-------

<p> Fix padding on codeselectors.

00019f7bd7f6c90d8243f6c5e98323efcdcd9769

-------

<p> Override link colors for callout sections so there aren't contrast issues with the theme.

49a68d45a123f133bedd8298e26fb953238268bc

-------

<p> Wrap the sidenav and article content in a flexbox to avoid issues with content overflowing weirdly on smaller screens.

Fixes https://github.com/google/dagger/issues/1886

e6d7a5a3a9d4745349d789ee3b5b8b9e23cd3f99