### PR TITLE
MOE Sync 2020-06-17

### DIFF
--- a/google/src/main/java/com/google/common/flogger/GoogleLogger.java
+++ b/google/src/main/java/com/google/common/flogger/GoogleLogger.java
@@ -82,9 +82,12 @@ public final class GoogleLogger extends AbstractLogger<GoogleLogger.Api> {
     // dramatically affects the ratio of enabled to disabled log statements, but in those cases,
     // the cost of this method is trivial compared to the work of actually logging.
     //
-    // We have also worked to avoid exceeding the 35-bytecode heuristic for inlining decisions.
-    // TODO(cpovirk): Add a test to ensure we don't exceed it again (if we find that the method size
-    // affects performance noticeably).
+    // As a general optimization, we have worked to avoid exceeding the 35-bytecode heuristic for
+    // inlining decisions. However, it's not clear that this helps performance. We could further
+    // reduce bytecodes by switching from || to | (which may affect performance in other ways).
+    // Conceivably we could do even better by writing our own bytecode to replace load and store
+    // operations with stack management. Perhaps all this would help to enable multiple levels of
+    // the call tree to be inlined?
     boolean isLoggable = isLoggable(level);
     boolean isForced = Platform.shouldForceLogging(getName(), level, isLoggable);
     if (isLoggable || isForced) {
@@ -95,7 +98,7 @@ public final class GoogleLogger extends AbstractLogger<GoogleLogger.Api> {
 
   /*
    * Extracted to a separate method to keep at(Level) from exceeding the 35-bytecode heuristic for
-   * inlining decisions.
+   * inlining decisions. But see discussion in at(Level).
    */
   private Context newContext(Level level, boolean isForced) {
     return new Context(level, isForced);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update comments to reflect that our optimization attempts haven't clearly made a difference.

Another thing we could try:

Instead of having at(Level) call getName(), we could call getName() in the constructor and stash it in a field for at(Level) to read. This wouldn't reduce the size of at(Level) itself, but it would reduce the size of {at(Level) + the methods it calls}, which is another thing that could conceivably(??) help with inlining.

But that would be a user-visible change if getName() changes value after the call. I notice that getName() is non-final but also not currently overridden. It delegates to getLoggerName(), which has a number of implementations, including AbstractBackend's, which delegates to java.util.logging.Logger.getName(), which reads an effectively final field. So that _one_ case is probably safe?

3526c543f63593a81f0ff74e0321dc56880cd59a