### PR TITLE
MOE Sync 2020-07-10

### DIFF
--- a/api/src/test/java/com/google/common/flogger/util/FastStackGetterTest.java
+++ b/api/src/test/java/com/google/common/flogger/util/FastStackGetterTest.java
@@ -19,10 +19,14 @@ package com.google.common.flogger.util;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+// Since JDK 11 was released the internal class used to implement "fast" stack access used have
+// been replaced by StackWalker, but that's difficult to integrate into Flogger at the moment.
+@Ignore  // b/142270173
 @RunWith(JUnit4.class)
 public class FastStackGetterTest {
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ignore the fast stack getter tests since JDK11 release (need to integrate StackWalker into Flogger neatly somehow).

RELNOTES=Disable problematic test until StackWalker is integrated.

61e80675e5db18186a984bcc9eeee562f3a3cbd9