### PR TITLE
MOE Sync 2020-07-13

### DIFF
--- a/google/src/main/java/com/google/common/flogger/GoogleLogContext.java
+++ b/google/src/main/java/com/google/common/flogger/GoogleLogContext.java
@@ -51,4 +51,5 @@ public abstract class GoogleLogContext<
   protected final MessageParser getMessageParser() {
     return DefaultPrintfMessageParser.getInstance();
   }
+
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fixing testing issues with stack analysis caused by JDK 11 release.

RELNOTES=Fixing stack analysis tests for recent JDK releases.

f99a6292786fe1d8f56be44b83abb05579c859c4

-------

<p> Making GoogleLogContext aware of tags so it can add a default small stack to the log statement (small is by far the most common size people use when they add stack manually).

d262b2e6807d23b9ebd85f6c955b9e39156878fd