### PR TITLE
MOE Sync 2020-08-06

### DIFF
--- a/api/src/main/java/com/google/common/flogger/backend/KeyValueHandler.java
+++ b/api/src/main/java/com/google/common/flogger/backend/KeyValueHandler.java
@@ -19,8 +19,9 @@ package com.google.common.flogger.backend;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
- * Callback interface to handle additional contextual key/value pairs with log statements. Used
- * for both {@code Tags} and {@code Metadata}.
+ * Callback interface to handle additional contextual {@code Metadata} and {@code Tags} in log
+ * statements. This interface is only intended for use by logger backend implementations as part of
+ * formatting metadata, and should not be used in any general application code.
  */
 public interface KeyValueHandler {
   /**

--- a/api/src/main/java/com/google/common/flogger/backend/SimpleMessageFormatter.java
+++ b/api/src/main/java/com/google/common/flogger/backend/SimpleMessageFormatter.java
@@ -37,6 +37,9 @@ import java.util.Formattable;
 import java.util.FormattableFlags;
 import java.util.Formatter;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
 import java.util.logging.Level;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -251,9 +254,25 @@ public final class SimpleMessageFormatter extends MessageBuilder<StringBuilder>
       key.emit(metadata.getValue(n), kvf);
     }
     if (tags != null) {
-      tags.emitAll(kvf);
+      emitAllTags(tags, kvf);
     }
     kvf.done();
+  }
+
+  /** Emits all the key/value pairs of this Tags instance to the given consumer. */
+  private static void emitAllTags(Tags tags, KeyValueHandler out) {
+    for (Map.Entry<String, SortedSet<Object>> e : tags.asMap().entrySet()) {
+      // Remember that tags can exist without values.
+      String key = e.getKey();
+      Set<Object> values = e.getValue();
+      if (!values.isEmpty()) {
+        for (Object value : values) {
+          out.handle(key, value);
+        }
+      } else {
+        out.handle(key, null);
+      }
+    }
   }
 
   private static boolean shouldFormat(MetadataKey<?> key, MetadataPredicate metadataPredicate) {

--- a/api/src/main/java/com/google/common/flogger/backend/Tags.java
+++ b/api/src/main/java/com/google/common/flogger/backend/Tags.java
@@ -324,7 +324,7 @@ public final class Tags {
   }
 
   /** Emits all the key/value pairs of this Tags instance to the given consumer. */
-  public void emitAll(KeyValueHandler out) {
+  void emitAll(KeyValueHandler out) {
     for (Entry<String, SortedSet<Object>> e : map.entrySet()) {
       // Remember that tags can exist without values.
       String key = e.getKey();

--- a/api/src/main/java/com/google/common/flogger/util/Checks.java
+++ b/api/src/main/java/com/google/common/flogger/util/Checks.java
@@ -38,6 +38,12 @@ public class Checks {
     }
   }
 
+  public static void checkState(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalStateException(message);
+    }
+  }
+
   /** Checks if the given string is a valid metadata identifier. */
   public static String checkMetadataIdentifier(String s) {
     // Note that we avoid using regular expressions here, since we've not used it anywhere else


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Introducing a builder API for scopes which encourages better use by guiding users to add metadata to scopes only at the point of creation. This also deprecates several existing methods and strongly discourages post-creation modification (there are still reasons people might want this though, especially for things like enabling more logging, which could happen asynchronously).

Tidied up some inconsistent documentation and documentation errors, and reordered some methods to just bring things together a bit better.

I think Gerrit uses the existing API (if not, they should migrate from the ad hoc API they had), so while this CL shouldn't break anyone, it's worth calling out for Gerrit.

RELNOTES=Improving the scoped logging context API and deprecating some methods.

23ce3420c6ce39c0177e0bcefebbc9b6f17282f4

-------

<p> Preparing for a migration from old "backend" Tags class to the new "context" package version. This pre-work CL:
* Makes new targets publicly visible as necessary.
* Untangles some otherwise awkward public uses of an internal API (the KeyValueHandler was never meant for general use outside backend implementations). If I didn't do this I'd have a circular dependency on the new context package.

f94d8bc93aa8b90732069590a84e5eee46457466