### PR TITLE
MOE Sync 2020-08-14

### DIFF
--- a/api/src/main/java/com/google/common/flogger/backend/Platform.java
+++ b/api/src/main/java/com/google/common/flogger/backend/Platform.java
@@ -234,12 +234,12 @@ public abstract class Platform {
    * expected. It should contain the platform name along with any configurable elements
    * (e.g. plugin services) and their settings. It is recommended (though not required) that this
    * string is formatted with one piece of configuration per line in a tabular format, such as:
-   * <pre>
+   * <pre>{@code
    * platform: <human readable name>
    * formatter: com.example.logging.FormatterPlugin
    * formatter.foo: <"foo" settings for the formatter plugin>
    * formatter.bar: <"bar" settings for the formatter plugin>
-   * </pre>
+   * }</pre>
    * It is not required that this string be machine parseable (though it should be stable).
    */
   public static String getConfigInfo() {

--- a/api/src/main/java/com/google/common/flogger/backend/system/LoggingContext.java
+++ b/api/src/main/java/com/google/common/flogger/backend/system/LoggingContext.java
@@ -17,68 +17,42 @@
 package com.google.common.flogger.backend.system;
 
 import com.google.common.flogger.context.Tags;
-import java.util.logging.Level;
+import com.google.common.flogger.context.ContextDataProvider;
+import com.google.common.flogger.context.LogLevelMap;
+import com.google.common.flogger.context.ScopedLoggingContext;
+import java.io.Closeable;
 
 /**
- * An API for injecting scoped metadata for log statements (either globally or on a per-request
- * basis). This is implemented as an abstract class (rather than an interface) to reduce to risk of
- * breaking existing implementations if the API changes.
- *
- * <h2>Essential Implementation Restrictions</h2>
- *
- * Any implementation of this API <em>MUST</em> follow the rules listed below to avoid any risk of
- * re-entrant code calling during logger initialization. Failure to do so risks creating complex,
- * hard to debug, issues with Flogger configuration.
- *
- * <ol>
- *   <li>Implementations <em>MUST NOT</em> attempt any logging in static methods or constructors.
- *   <li>Implementations <em>MUST NOT</em> statically depend on any unknown code.
- *   <li>Implementations <em>MUST NOT</em> depend on any unknown code in constructors.
- * </ol>
- *
- * <p>Note that logging and calling arbitrary unknown code (which might log) are permitted inside
- * the instance methods of this API, since they are not called during platform initialization. The
- * easiest way to achieve this is to simply avoid having any non-trivial static fields or any
- * instance fields at all in the implementation.
- *
- * <p>While this sounds onerous it's not difficult to achieve because this API is a singleton, and
- * can delay any actual work until its methods are called. For example if any additional state is
- * required in the implementation, it can be held via a "lazy holder" to defer initialization.
+ * Deprecated context API, to be replaced by {@link ContextDataProvider} and {@link
+ * ScopedLoggingContext}.
  */
-public abstract class LoggingContext {
-  /**
-   * Returns whether the given logger should have logging forced at the specified level. When
-   * logging is forced for a log statement it will be emitted regardless or the normal log level
-   * configuration of the logger and ignoring any rate limiting or other filtering.
-   *
-   * <p>A default implementation of this method should simply {@code return false}.
-   *
-   * <p>{@code loggerName} can be used to look up specific configuration, such as log level, for
-   * the logger, to decide if a log statement should be forced. This information might vary
-   * depending on the context in which this call is made, so the result should not be cached.
-   *
-   * <p>{@code isEnabledByLevel} indicates that the log statement is enabled according to its log
-   * level, but a {@code true} value does not necessarily indicate that logging will occur, due to
-   * rate limiting or other conditional logging mechanisms. To bypass conditional logging and
-   * ensure that an enabled log statement will be emitted, this method should return {@code true}
-   * if {@code isEnabledByLevel} was {@code true}.
-   *
-   * <p>WARNING: This method MUST complete quickly and without allocating any memory. It is
-   * invoked for every log statement regardless of logging configuration, so any implementation
-   * must go to every possible length to be efficient.
-   *
-   * @param loggerName the fully qualified logger name (e.g. "com.example.SomeClass")
-   * @param level the level of the log statement being invoked
-   * @param isEnabledByLevel whether the logger is enabled at the given level
-   */
-  public abstract boolean shouldForceLogging(
-      String loggerName, Level level, boolean isEnabledByLevel);
+public abstract class LoggingContext extends ContextDataProvider {
+  // Needed temporarily while old LoggingContext based implementations are migrated away from.
+  private static final ScopedLoggingContext NO_OP_API = new NoOpScopedLoggingContext();
 
-  /**
-   * Returns a set of tags to be added to a log statement. These tags can be used to provide
-   * additional contextual metadata to log statements (e.g. request IDs).
-   *
-   * <p>A default implementation of this method should simply return {@code Tags.empty()}.
-   */
-  public abstract Tags getTags();
+  @Override
+  public ScopedLoggingContext getContextApiSingleton() {
+    return NO_OP_API;
+  }
+
+  private static final class NoOpScopedLoggingContext extends ScopedLoggingContext
+      implements Closeable {
+    @Override
+    public Closeable withNewScope() {
+      return this;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public boolean addTags(Tags tags) {
+      return false;
+    }
+
+    @Override
+    public boolean applyLogLevelMap(LogLevelMap m) {
+      return false;
+    }
+  }
 }

--- a/api/src/main/java/com/google/common/flogger/context/ContextDataProvider.java
+++ b/api/src/main/java/com/google/common/flogger/context/ContextDataProvider.java
@@ -84,8 +84,9 @@ public abstract class ContextDataProvider {
    * @param level the level of the log statement being invoked
    * @param isEnabledByLevel whether the logger is enabled at the given level
    */
-  public abstract boolean shouldForceLogging(
-      String loggerName, Level level, boolean isEnabledByLevel);
+  public boolean shouldForceLogging(String loggerName, Level level, boolean isEnabledByLevel) {
+    return false;
+  }
 
   /**
    * Returns a set of tags to be added to a log statement. These tags can be used to provide

--- a/api/src/test/java/com/google/common/flogger/context/ContextDataProviderTest.java
+++ b/api/src/test/java/com/google/common/flogger/context/ContextDataProviderTest.java
@@ -21,17 +21,13 @@ import static org.junit.Assert.fail;
 
 import com.google.common.flogger.context.ScopedLoggingContext.InvalidLoggingScopeStateException;
 import java.io.Closeable;
-import java.util.logging.Level;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+// TODO: Implement an abstract test suite to allow new implementations to be tested easily.
 @RunWith(JUnit4.class)
 public class ContextDataProviderTest {
-
-  private static final Tags TEST_TAGS = Tags.builder().addTag("foo", "bar").build();
-  private static final LogLevelMap TEST_MAP =
-      LogLevelMap.builder().add(Level.FINEST, String.class).build();
 
   // A context which fails when the scope is closed. Used to verify that user errors are
   // prioritized in cases where errors cause scopes to be exited.
@@ -54,38 +50,6 @@ public class ContextDataProviderTest {
           return false;
         }
       };
-
-  @Test
-  public void testNoOpImplementation() {
-    ContextDataProvider ctxData = new NoOpContextDataProvider();
-    assertThat(ctxData.getTags()).isEqualTo(Tags.empty());
-    assertThat(ctxData.shouldForceLogging("java.lang.String", Level.FINE, true)).isFalse();
-
-    ScopedLoggingContext api = ctxData.getContextApiSingleton();
-    assertThat(api.addTags(TEST_TAGS)).isFalse();
-    assertThat(api.applyLogLevelMap(TEST_MAP)).isFalse();
-  }
-
-  @Test
-  public void testNoOpScopesHaveNoEffect() throws Exception {
-    ContextDataProvider ctxData = new NoOpContextDataProvider();
-    ScopedLoggingContext api = ctxData.getContextApiSingleton();
-
-    boolean didTest =
-        api.call(
-            () -> {
-              // API reports failure to modify the current context.
-              assertThat(api.addTags(TEST_TAGS)).isFalse();
-              assertThat(api.applyLogLevelMap(TEST_MAP)).isFalse();
-
-              // And there's no effect on the current context.
-              assertThat(ctxData.getTags()).isEqualTo(Tags.empty());
-              assertThat(ctxData.shouldForceLogging("java.lang.String", Level.FINE, true))
-                  .isFalse();
-              return true;
-            });
-    assertThat(didTest).isTrue();
-  }
 
   @Test
   public void testErrorHandlingWithoutUserError() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make Platform implementations use ContextDataProvider instead of LoggingContext (which will be deleted soon).

RELNOTES=Make Platform implementations use ContextDataProvider instead of LoggingContext (which will be deleted soon).

09a782c732070795dcef9ac8dc02101a335b94b1