### PR TITLE
Support change the context prefix and suffix format of KeyValueFormatter

### DIFF
--- a/api/src/main/java/com/google/common/flogger/LogContext.java
+++ b/api/src/main/java/com/google/common/flogger/LogContext.java
@@ -174,6 +174,20 @@ public abstract class LogContext<
      */
     public static final MetadataKey<StackSize> CONTEXT_STACK_SIZE =
         MetadataKey.single("stack_size", StackSize.class);
+
+    /**
+     * Key associated with the metadata for specifying {@code KeyValueFormatter.prefix} with a log
+     * statement.
+     */
+    public static final MetadataKey<String> CONTEXT_PREFIX =
+            MetadataKey.single("prefix", String.class);
+
+    /**
+     * Key associated with the metadata for specifying {@code KeyValueFormatter.suffix} with a log
+     * statement.
+     */
+    public static final MetadataKey<String> CONTEXT_SUFFIX =
+            MetadataKey.single("suffix", String.class);
   }
 
   static final class MutableMetadata extends Metadata {

--- a/api/src/main/java/com/google/common/flogger/backend/system/AbstractLogRecord.java
+++ b/api/src/main/java/com/google/common/flogger/backend/system/AbstractLogRecord.java
@@ -152,7 +152,7 @@ public abstract class AbstractLogRecord extends LogRecord {
    * requiring a new field in this class (to cut down on instance size).
    */
   protected LogMessageFormatter getLogMessageFormatter() {
-    return SimpleMessageFormatter.getDefaultFormatter();
+    return SimpleMessageFormatter.getDefaultFormatter(data.getMetadata());
   }
 
   @Override

--- a/api/src/test/java/com/google/common/flogger/backend/system/AbstractLogRecordTest.java
+++ b/api/src/test/java/com/google/common/flogger/backend/system/AbstractLogRecordTest.java
@@ -31,7 +31,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class AbstractLogRecordTest {
   private static final LogMessageFormatter DEFAULT_FORMATTER =
-      SimpleMessageFormatter.getDefaultFormatter();
+      SimpleMessageFormatter.getDefaultFormatter(Metadata.empty());
 
   private static final LogMessageFormatter TEST_MESSAGE_FORMATTER =
       new LogMessageFormatter() {


### PR DESCRIPTION
- Add MetadataKey "prefix" and "suffix" of LogContext
- Modify to generate LogMessageFormatter using MetaData

Related: #275 