### PR TITLE
Adding a static helper to expose the ScopeType constructor for ScopedLoggingContext.

### DIFF
--- a/api/src/main/java/com/google/common/flogger/context/ScopedLoggingContexts.java
+++ b/api/src/main/java/com/google/common/flogger/context/ScopedLoggingContexts.java
@@ -51,7 +51,7 @@ public final class ScopedLoggingContexts {
 
   /**
    * Creates a new {@link ScopedLoggingContext.Builder} to which additional logging metadata can be
-   * attached before being installed or used to wrap some existing code.
+   * attached, before being installed or used to wrap some existing code.
    *
    * <pre>{@code
    * Foo result = ScopedLoggingContexts.newContext()
@@ -61,6 +61,25 @@ public final class ScopedLoggingContexts {
    */
   public static ScopedLoggingContext.Builder newContext() {
     return ScopedLoggingContext.getInstance().newContext();
+  }
+
+  /**
+   * Creates a new {@link ScopedLoggingContext.Builder} bound to the given {@link ScopeType}, to
+   * which additional logging metadata can be attached, before being installed or used to wrap some
+   * existing code.
+   *
+   * <p>Specifying a scope type means that any tasks run within this context will have a different
+   * scope attached, ensuring that stateful logging (e.g. rate limiting) will be handled separately
+   * for each invocation. This can help ensure that even rare situations will appear in logs.
+   *
+   * <pre>{@code
+   * ScopedLoggingContexts.newContext(ScopeType.REQUEST)
+   *     .withTags(Tags.of("request_id", request.getId))
+   *     .run(() -> handleRequest(request));
+   * }</pre>
+   */
+  public static ScopedLoggingContext.Builder newContext(ScopeType scopeType) {
+    return ScopedLoggingContext.getInstance().newContext(scopeType);
   }
 
   /**


### PR DESCRIPTION
This was omitted when ScopeType support was added.