### PR TITLE
Run buildifier to add loads

### DIFF
--- a/grpc/BUILD
+++ b/grpc/BUILD
@@ -6,6 +6,7 @@
 
 load("@google_bazel_common//testing:test_defs.bzl", "gen_java_tests")
 load("@google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
+load("@rules_java//java:java_library.bzl", "java_library")
 load("//tools:maven.bzl", "pom_file")
 
 GRPC_CONTEXT_SRCS = glob(["src/main/java/**/*.java"])


### PR DESCRIPTION
Run `buildifier --lint=fix  -r -v`. This adds loads for the rules that were removed from Bazel 8. By Bazel 9 automatic loads will be disabled and all loads will need to be explicitly present.

See: https://github.com/bazelbuild/bazel/issues/25755