### PR TITLE
performance optimisation for Log4j2LoggerBackend - get log4j context direct from the logger, and reduce allocations in the common path

### DIFF
--- a/log4j2/src/main/java/com/google/common/flogger/backend/log4j2/Log4j2LoggerBackend.java
+++ b/log4j2/src/main/java/com/google/common/flogger/backend/log4j2/Log4j2LoggerBackend.java
@@ -55,11 +55,11 @@ final class Log4j2LoggerBackend extends LoggerBackend {
   public void log(LogData logData) {
     // The caller is responsible to call isLoggable() before calling this method to ensure that only
     // messages above the given threshold are logged.
-    logger.get().log(toLog4jLogEvent(logger.getName(), logData));
+    logger.get().log(toLog4jLogEvent(logger, logData));
   }
 
   @Override
   public void handleError(RuntimeException error, LogData badData) {
-    logger.get().log(toLog4jLogEvent(logger.getName(), error, badData));
+    logger.get().log(toLog4jLogEvent(logger, error, badData));
   }
 }


### PR DESCRIPTION
`LoggerContext.getContext(false)` can be very expensive - instead get the context from the logger. Also reduce work (and allocations) for the common case of no metadata