### PR TITLE
Fix spelling of overridden in LogContext javadoc

### DIFF
--- a/api/src/main/java/com/google/common/flogger/LogContext.java
+++ b/api/src/main/java/com/google/common/flogger/LogContext.java
@@ -628,7 +628,7 @@ public abstract class LogContext<LOGGER extends AbstractLogger<API>, API extends
 
   /**
    * Callback to allow custom log contexts to apply additional rate limiting behaviour. This should
-   * be called from within an overriden {@code postProcess()} method. Typically this is invoked
+   * be called from within an overridden {@code postProcess()} method. Typically this is invoked
    * after calling {@code super.postProcess(logSiteKey)}, such as:
    *
    * <pre>{@code protected boolean postProcess(@Nullable LogSiteKey logSiteKey) {


### PR DESCRIPTION
## Summary
- Correct `overriden` → `overridden` in the `LogContext` rate-limiter callback javadoc.

## Test plan
- [x] Docs-only change; no behavior change